### PR TITLE
[Sprint 1] 로그인 페이지, 월별 내역 페이지, 달력 페이지, 통계 페이지에 대한 라우팅 설정

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Login from './pages/Login';
 import Main from './pages/Main';
 import Calendar from './pages/Calendar';
 import Statistics from './pages/Statistics';
@@ -9,6 +10,7 @@ const Router = () => {
         <BrowserRouter>
             <Routes>
                 <Route exact path="/" element={<Main />} />
+                <Route exact path="/login" element={<Login />} />
                 <Route exact path="/calendar" element={<Calendar />} />
                 <Route exact path="/statistics" element={<Statistics />} />
             </Routes>

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import Test1 from './pages/Test1';
-import Test2 from './pages/Test2';
+import Main from './pages/Main';
+import Calendar from './pages/Calendar';
+import Statistics from './pages/Statistics';
 
 const Router = () => {
     return (
         <BrowserRouter>
             <Routes>
-                <Route exact path="/" element={<Test1 />} />
-                <Route exact path="/test" element={<Test2 />} />
+                <Route exact path="/" element={<Main />} />
+                <Route exact path="/calendar" element={<Calendar />} />
+                <Route exact path="/statistics" element={<Statistics />} />
             </Routes>
         </BrowserRouter>
     );

--- a/frontend/src/pages/Calendar/index.jsx
+++ b/frontend/src/pages/Calendar/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Calendar = () => {
+    return <div>달력 페이지 입니다.</div>;
+};
+
+export default Calendar;

--- a/frontend/src/pages/Login/index.jsx
+++ b/frontend/src/pages/Login/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Login = () => {
+    return <div>로그인 페이지 입니다.</div>;
+};
+
+export default Login;

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Main = () => {
+    return <div>메인(월별 내역 페이지) 페이지 입니다.</div>;
+};
+
+export default Main;

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Statistics = () => {
+    return <div>통계 페이지 입니다.</div>;
+};
+
+export default Statistics;

--- a/frontend/src/pages/Test1/index.jsx
+++ b/frontend/src/pages/Test1/index.jsx
@@ -1,9 +1,0 @@
-import React, { useState } from 'react';
-
-const test1 = () => {
-    const [value, setValue] = useState(1);
-
-    return <div>{value}</div>;
-};
-
-export default test1;

--- a/frontend/src/pages/Test2/index.jsx
+++ b/frontend/src/pages/Test2/index.jsx
@@ -1,9 +1,0 @@
-import React, { useState } from 'react';
-
-const test2 = () => {
-    const [value, setValue] = useState(2);
-
-    return <div>{value}</div>;
-};
-
-export default test2;


### PR DESCRIPTION
## 구현한 내용
* 로그인 페이지, 메인페이지(월별 내역 페이지), 달력 페이지, 통계 페이지에 대한 라우팅을 설정했습니다.

## 어려웠던 점 및 해결한 방향
없습니다.

## 체크리스트
- [x]  `console.log` 지우고 올리기
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지