### PR TITLE
[Sprint 1] 인증이 필요한 페이지에 대한 AuthRouter 설정 추가

### DIFF
--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -1,21 +1,45 @@
 import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+
 import Main from './pages/Main';
 import Login from './pages/Login';
 import Calendar from './pages/Calendar';
 import Statistics from './pages/Statistics';
 import GithubOauth from './pages/GithubOauth';
 
+import AuthRoute from './components/AuthRoute';
+
 const Router = () => {
     return (
         <BrowserRouter>
             {/* TODO 설정된 경로 이외의 경로에 대한 Not Found 페이지 렌더링 */}
             <Routes>
-                <Route path="/" element={<Main />} />
                 <Route path="/login" element={<Login />} />
-                <Route path="/calendar" element={<Calendar />} />
-                <Route path="/statistics" element={<Statistics />} />
                 <Route path="/auth" element={<GithubOauth />} />
+                <Route
+                    path="/"
+                    element={
+                        <AuthRoute>
+                            <Main />
+                        </AuthRoute>
+                    }
+                />
+                <Route
+                    path="/calendar"
+                    element={
+                        <AuthRoute>
+                            <Calendar />
+                        </AuthRoute>
+                    }
+                />
+                <Route
+                    path="/statistics"
+                    element={
+                        <AuthRoute>
+                            <Statistics />
+                        </AuthRoute>
+                    }
+                />
             </Routes>
         </BrowserRouter>
     );

--- a/frontend/src/components/AuthRoute/index.jsx
+++ b/frontend/src/components/AuthRoute/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+// eslint-disable-next-line react/prop-types
+const AuthRoute = ({ children }) => {
+    const userJwt = sessionStorage.getItem('userJwt');
+    return userJwt ? children : <Navigate replace to="/login" />;
+};
+
+export default AuthRoute;


### PR DESCRIPTION
## 구현한 내용
* 인증이 필요한 페이지에 대해 AuthRouter 컴포넌트를 만들어서 적용했습니다.
* AuthRouter에서는 현재 인증이 되어있는 상태인지 확인 후 상태에 맞는 경로로 이동합니다.

## 어려웠던 점 및 해결한 방향
1. react-router-dom v6으로 업데이트 함에 따라 변경된 auth 설정 방법
* v5 방식
```
// components/AuthRouter/index.jsx
const AuthRoute = ({ component: Component, ...rest }) => {
  return (
    <Route
      {...rest}
      render={props => {
        const userJwt = sessionStorage.getItem('userJwt');
        if (!userJwt) {
          const from = '/login';
          return <Redirect to={from} />;
        }

        if (Component) {
          return <Component {...props} />;
        }

        return null;
      }}
    />
  );
};

// Router.jsx
<Switch>
  <AuthRoute
    path="/"
    exact
    component={() => <Home />}
  />
</Switch>
```
* v6 부터는 Redirect가 Navigate로, Switch가 Routes로 대체되었고 Routes 아래에는 Route이외에는 사용불가
* 따라서, AuthRoute 같이 직접 만든 Route를 Routes 아래에 바로 넣지 못하는 이슈발생
* 결론적으로 element 안에 AuthRoute 설정을 추가함으로써 해결
```
// components/AuthRouter/index.jsx
const AuthRoute = ({ children }) => {
    const userJwt = sessionStorage.getItem('userJwt');
    return userJwt ? children : <Navigate replace to="/login" />;
};
// Router.jsx
<Routes>
  <Route
    path="/calendar"
    element={
      <AuthRoute>
          <Calendar />
      </AuthRoute>
    }
  />
</Routes>
```

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지