### PR TITLE
[Sprint 1] 헤더의 현재 페이지 흰색 스타일 적용 및 날짜 변경 기능 구현 - #3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",
+        "recoil": "^0.5.2",
         "styled-components": "^5.3.3",
         "styled-reset": "^4.3.4"
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     },
     "dependencies": {
         "axios": "^0.25.0",
+        "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
 import GlobalStyle from './styles/GlobalStyle';
@@ -7,12 +8,12 @@ import Router from './Router';
 
 const App = () => {
     return (
-        <>
+        <RecoilRoot>
             <GlobalStyle />
             <ThemeProvider theme={theme}>
                 <Router />
             </ThemeProvider>
-        </>
+        </RecoilRoot>
     );
 };
 

--- a/frontend/src/components/Header/index.jsx
+++ b/frontend/src/components/Header/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -6,7 +7,7 @@ import previous from '../../../public/assets/previous-button.svg';
 import next from '../../../public/assets/next-button.svg';
 import { MAX_MOBILE_DEVICE } from '../../utils/device-size';
 
-const Header = () => {
+const Header = ({ current }) => {
     return (
         <Wrapper>
             <Title>JH Account Book</Title>
@@ -20,12 +21,22 @@ const Header = () => {
                 </ArrowButton>
             </DateBox>
             <PageBox>
-                <PageTarget to="/">내역</PageTarget>
-                <PageTarget to="/calendar">달력</PageTarget>
-                <PageTarget to="/statistics">통계</PageTarget>
+                <PageTarget to="/" isSelected={current === 'main'}>
+                    내역
+                </PageTarget>
+                <PageTarget to="/calendar" isSelected={current === 'calendar'}>
+                    달력
+                </PageTarget>
+                <PageTarget to="/statistics" isSelected={current === 'statistics'}>
+                    통계
+                </PageTarget>
             </PageBox>
         </Wrapper>
     );
+};
+
+Header.propTypes = {
+    current: PropTypes.string.isRequired,
 };
 
 export default Header;
@@ -102,7 +113,9 @@ const PageTarget = styled(Link)`
     font-weight: bold;
     font-size: ${({ theme }) => theme.fontSize.small};
 
-    color: ${({ theme }) => theme.color.black};
+    color: ${({ theme }) =>
+        (props) =>
+            props.isSelected ? theme.color.white : theme.color.black};
 
     &:hover {
         cursor: pointer;

--- a/frontend/src/components/Header/index.jsx
+++ b/frontend/src/components/Header/index.jsx
@@ -1,23 +1,35 @@
 import React from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+
+import { dateState } from '../../recoil/date/atom';
+import { shapedDateState } from '../../recoil/date/selector';
 
 import previous from '../../../public/assets/previous-button.svg';
 import next from '../../../public/assets/next-button.svg';
 import { MAX_MOBILE_DEVICE } from '../../utils/device-size';
 
 const Header = ({ current }) => {
+    const setDate = useSetRecoilState(dateState);
+    const shapedDate = useRecoilValue(shapedDateState);
+
+    const changeDate = (sign) => {
+        const value = sign === '+' ? 1 : -1;
+        setDate((prev) => ({ ...prev, month: prev.month + value }));
+    };
+
     return (
         <Wrapper>
             <Title>JH Account Book</Title>
             <DateBox>
                 <ArrowButton>
-                    <img src={previous} />
+                    <img src={previous} onClick={() => changeDate('-')} />
                 </ArrowButton>
-                <Date>2022년 01월</Date>
+                <Date>{shapedDate}</Date>
                 <ArrowButton>
-                    <img src={next} />
+                    <img src={next} onClick={() => changeDate('+')} />
                 </ArrowButton>
             </DateBox>
             <PageBox>

--- a/frontend/src/components/Header/index.jsx
+++ b/frontend/src/components/Header/index.jsx
@@ -61,10 +61,6 @@ const Title = styled.h1`
     font-size: ${({ theme }) => theme.fontSize.medium};
 
     color: ${({ theme }) => theme.color.white};
-
-    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        display: none;
-    }
 `;
 
 const DateBox = styled.div`

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -6,7 +6,7 @@ import Header from '../../components/Header';
 const Main = () => {
     return (
         <Wrapper>
-            <Header />
+            <Header current={'main'} />
         </Wrapper>
     );
 };

--- a/frontend/src/recoil/date/atom.js
+++ b/frontend/src/recoil/date/atom.js
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+export const dateState = atom({
+    key: 'dateState',
+    default: {
+        year: new Date().getFullYear(),
+        month: new Date().getMonth(),
+    },
+});

--- a/frontend/src/recoil/date/selector.js
+++ b/frontend/src/recoil/date/selector.js
@@ -1,0 +1,16 @@
+import { selector } from 'recoil';
+
+import { dateState } from './atom';
+
+export const shapedDateState = selector({
+    key: 'shapedDateState',
+    get: ({ get }) => {
+        const { year, month } = get(dateState);
+
+        const nowDate = new Date(year, month);
+        const convertedYear = nowDate.getFullYear();
+        const convertedMonth = nowDate.getMonth() + 1;
+
+        return `${convertedYear}년 ${convertedMonth}월`;
+    },
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5097,7 +5097,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3390,6 +3390,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -5228,6 +5233,13 @@ rechoir@^0.7.0:
   integrity sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==
   dependencies:
     resolve "^1.9.0"
+
+recoil@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.5.2.tgz#61fecce3b4dc91127a595586cf7369e2811ba024"
+  integrity sha512-Edibzpu3dbUMLy6QRg73WL8dvMl9Xqhp+kU+f2sJtXxsaXvAlxU/GcnDE8HXPkprXrhHF2e6SZozptNvjNF5fw==
+  dependencies:
+    hamt_plus "1.0.2"
 
 redent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## 구현한 내용
* 반응형 헤더에서 타이틀도 다시 추가하도록 적용했습니다.
* 헤더의 현재 페이지 흰색 스타일을 적용했습니다.
* 헤더의 날짜 arrow 버튼(좌, 우) 클릭 시 날짜가 변경되는 로직을 구현했습니다. 

## 어려웠던 점 및 해결한 방향
어려웠던 점은 크게 없었고, Date( ) 생성자의 활용법에 대해 좀 더 학습할 수 있었습니다.
* 그중에 가장 기억나는 개념은 new Date(년, 월, 일)의 형태로 적용할 때 유효하지 않은 값을 입력해도 숫자의 형태로 기입 시 내부적으로 변환해서 올바른 날짜를 제공해준다는 것을 새롭게 알게 되었습니다.
* ex. new Date(2022, -1)의 결과는 2021년 12월을 나타냅니다. 

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지