### PR TITLE
[Sprint 1] 프론트엔드 테스트코드 추가 작성 및 기존의 잘못된 테스트 수정

### DIFF
--- a/frontend/src/components/Transaction/hooks.js
+++ b/frontend/src/components/Transaction/hooks.js
@@ -1,0 +1,17 @@
+import { useSetRecoilState } from 'recoil';
+
+import { modalState } from '../../recoil/modal/atom';
+
+export const useCurrentModal = (transaction) => {
+    const setCurrentModal = useSetRecoilState(modalState);
+
+    const changeModalState = () => {
+        const state = {
+            current: 'transaction',
+            props: transaction,
+        };
+        setCurrentModal(state);
+    };
+
+    return [changeModalState];
+};

--- a/frontend/src/components/Transaction/index.jsx
+++ b/frontend/src/components/Transaction/index.jsx
@@ -1,20 +1,12 @@
 import React from 'react';
-import { useSetRecoilState } from 'recoil';
+
 import PropTypes from 'prop-types';
 
-import { modalState } from '../../recoil/modal/atom';
+import { useCurrentModal } from './hooks';
 import { Wrapper, OuterBox, Category, InnerBox, Content, Method, Cost } from './style';
 
 const Transaction = ({ transaction }) => {
-    const setCurrentModal = useSetRecoilState(modalState);
-
-    const changeModalState = () => {
-        const state = {
-            current: 'transaction',
-            props: transaction,
-        };
-        setCurrentModal(state);
-    };
+    const [changeModalState] = useCurrentModal(transaction);
 
     return (
         <Wrapper onClick={changeModalState}>

--- a/frontend/src/components/Transaction/index.jsx
+++ b/frontend/src/components/Transaction/index.jsx
@@ -11,13 +11,15 @@ const Transaction = ({ transaction }) => {
     return (
         <Wrapper onClick={changeModalState}>
             <OuterBox>
-                <Category>{transaction.category}</Category>
+                <Category data-testid="category">{transaction.category}</Category>
                 <InnerBox>
-                    <Content>{transaction.content}</Content>
-                    <Method>{transaction.method}</Method>
+                    <Content data-testid="content">{transaction.content}</Content>
+                    <Method data-testid="method">{transaction.method}</Method>
                 </InnerBox>
             </OuterBox>
-            <Cost>{transaction.sign + parseInt(transaction.cost).toLocaleString('ko-KR')}원</Cost>
+            <Cost data-testid="cost">
+                {transaction.sign + parseInt(transaction.cost).toLocaleString('ko-KR')}원
+            </Cost>
         </Wrapper>
     );
 };

--- a/frontend/src/components/Transaction/test.js
+++ b/frontend/src/components/Transaction/test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '../../test-utils';
+import '@testing-library/jest-dom';
+
+import Transaction from '.';
+
+const TEST_DATA = {
+    category: '카페/간식',
+    color: '#D092E2',
+    content: '녹차 스무디',
+    method: '현금',
+    sign: '-',
+    cost: '5700',
+    date: '2022-01-28',
+};
+
+describe('Transaction컴포넌트 테스트', () => {
+    it('트랜잭션 정보가 정상적으로 표시된다.', () => {
+        const shapedCost = `${TEST_DATA['sign']}${TEST_DATA['cost']}`;
+        render(<Transaction transaction={TEST_DATA} />);
+
+        const categorySpan = screen.getByTestId('category');
+        const contentSpan = screen.getByTestId('content');
+        const methodSpan = screen.getByTestId('method');
+        const costSpan = screen.getByTestId('cost');
+        expect(categorySpan).toHaveTextContent(TEST_DATA['category']);
+        expect(contentSpan).toHaveTextContent(TEST_DATA['content']);
+        expect(methodSpan).toHaveTextContent(TEST_DATA['method']);
+        expect(costSpan).toHaveTextContent(parseInt(shapedCost).toLocaleString('ko-KR'));
+    });
+});

--- a/frontend/src/components/Transactions/index.jsx
+++ b/frontend/src/components/Transactions/index.jsx
@@ -7,19 +7,12 @@ import TransactionModal from '../TransactionModal';
 import { useFilterdTransactions } from './hooks';
 import { checkState } from '../../recoil/check/atom';
 import { TransactionsContainer } from './style';
+import { makeDailyTransaction } from '../../utils/common/make-daily-transaction';
 
 const Transactions = () => {
     const check = useRecoilValue(checkState);
     const filterdTransactions = useFilterdTransactions(check);
-
-    const dailyTransactions = new Map();
-
-    filterdTransactions.forEach((rawTransaction) => {
-        const currentDate = rawTransaction.date;
-        if (dailyTransactions.has(currentDate)) {
-            dailyTransactions.get(currentDate).push(rawTransaction);
-        } else dailyTransactions.set(currentDate, [rawTransaction]);
-    });
+    const dailyTransactions = makeDailyTransaction(filterdTransactions);
 
     const shapedTransactions = Array.from(dailyTransactions.keys())
         .sort((a, b) => new Date(b) - new Date(a))

--- a/frontend/src/components/Transactions/test.js
+++ b/frontend/src/components/Transactions/test.js
@@ -1,12 +1,10 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { RecoilRoot } from 'recoil';
-import { ThemeProvider } from 'styled-components';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '../../test-utils';
 import '@testing-library/jest-dom';
 
 import Transactions from '.';
 import { checkState } from '../../recoil/check/atom';
-import theme from '../../styles/theme';
 import { transactions } from '../../mocks/transactions';
 
 const TOTAL_COUNT = transactions.length;
@@ -25,73 +23,52 @@ describe('해당 날짜(월 단위)의 모든 거래내역을 표시하는 Trans
         };
 
     it('지출 내역의 check box 상태가 false인 경우 지출 내역이 필터링되어 표시된다.', async () => {
-        // TODO test-utils 파일과 합치기
+        const TEST_DATA = {
+            totalCount: true,
+            income: true,
+            expenditure: false,
+        };
         render(
-            <RecoilRoot
-                initializeState={initializeState({
-                    totalCount: true,
-                    income: true,
-                    expenditure: false,
-                })}
-            >
-                <ThemeProvider theme={theme}>
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <Transactions />
-                    </Suspense>
-                </ThemeProvider>
+            <RecoilRoot initializeState={initializeState(TEST_DATA)}>
+                <Transactions />
             </RecoilRoot>,
         );
 
         const filterdTransactions = await screen.findAllByRole('listitem');
-
         const result = TOTAL_COUNT - EXPENDITURE_COUNT;
         expect(filterdTransactions).toHaveLength(result);
     });
 
     it('수입 내역의 check box 상태가 false인 경우 수입 내역이 필터링되어 표시된다.', async () => {
-        // TODO test-utils 파일과 합치기
+        const TEST_DATA = {
+            totalCount: true,
+            income: false,
+            expenditure: true,
+        };
         render(
-            <RecoilRoot
-                initializeState={initializeState({
-                    totalCount: true,
-                    income: false,
-                    expenditure: true,
-                })}
-            >
-                <ThemeProvider theme={theme}>
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <Transactions />
-                    </Suspense>
-                </ThemeProvider>
+            <RecoilRoot initializeState={initializeState(TEST_DATA)}>
+                <Transactions />
             </RecoilRoot>,
         );
 
         const filterdTransactions = await screen.findAllByRole('listitem');
-
         const result = TOTAL_COUNT - INCOME_COUNT;
         expect(filterdTransactions).toHaveLength(result);
     });
 
     it('지출, 수입 내역의 check box 상태가 false인 경우 0건이 표시된다.', async () => {
-        // TODO test-utils 파일과 합치기
+        const TEST_DATA = {
+            totalCount: true,
+            income: false,
+            expenditure: false,
+        };
         render(
-            <RecoilRoot
-                initializeState={initializeState({
-                    totalCount: true,
-                    income: false,
-                    expenditure: false,
-                })}
-            >
-                <ThemeProvider theme={theme}>
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <Transactions />
-                    </Suspense>
-                </ThemeProvider>
+            <RecoilRoot initializeState={initializeState(TEST_DATA)}>
+                <Transactions />
             </RecoilRoot>,
         );
 
         const filterdTransactions = await waitFor(() => screen.queryAllByRole('listitem'));
-
         const result = TOTAL_COUNT - INCOME_COUNT - EXPENDITURE_COUNT;
         expect(filterdTransactions).toHaveLength(result);
     });

--- a/frontend/src/utils/common/calculate-cost/test.js
+++ b/frontend/src/utils/common/calculate-cost/test.js
@@ -1,8 +1,8 @@
 import { calculateIncome, calculateExpenditure } from '.';
 import { transactions } from '../../../mocks/transactions';
 
-const INCOME = calculateIncome(transactions);
-const EXPENDITURE = calculateExpenditure(transactions);
+const INCOME = 300000;
+const EXPENDITURE = 259200;
 
 describe('수입, 지출 금액 계산 테스트', () => {
     it('수입 거래내역에 대한 총 금액을 반환한다.', () => {

--- a/frontend/src/utils/common/make-daily-transaction/index.js
+++ b/frontend/src/utils/common/make-daily-transaction/index.js
@@ -1,0 +1,12 @@
+export const makeDailyTransaction = (transactions) => {
+    const dailyTransactions = new Map();
+
+    transactions.forEach((transaction) => {
+        const currentDate = transaction.date;
+        if (dailyTransactions.has(currentDate)) {
+            dailyTransactions.get(currentDate).push(transaction);
+        } else dailyTransactions.set(currentDate, [transaction]);
+    });
+
+    return dailyTransactions;
+};

--- a/frontend/src/utils/common/make-daily-transaction/test.js
+++ b/frontend/src/utils/common/make-daily-transaction/test.js
@@ -1,0 +1,16 @@
+import { makeDailyTransaction } from '.';
+import { transactions } from '../../../mocks/transactions';
+
+const TEST_DATA = transactions;
+
+describe('일자별로 데이터를 나눠서 Map 형태로 반환하는 로직 테스트', () => {
+    it('거래내역을 일자별로 데이터를 나눠서 Map 형태로 반환한다.', () => {
+        const dailyTransactions = makeDailyTransaction(TEST_DATA);
+        expect(dailyTransactions.size).toEqual(3);
+
+        const sortedKeys = Array.from(dailyTransactions.keys()).sort(
+            (a, b) => new Date(a) - new Date(b),
+        );
+        expect(sortedKeys).toEqual(['2022-01-09', '2022-01-17', '2022-01-28']);
+    });
+});


### PR DESCRIPTION
## 구현한 내용
* 기존에 의미가 없던 테스트 코드를 수정했습니다. (https://github.com/jhLim97/account-book/pull/43/commits/f23b9bd81b7189ac69f72afb8526378192009375)
    * calculate-cost util 함수를 테스트하는데 TEST 데이터를 해당함수로 구한 값을 사용했었습니다.
    * 현재는 정확한 값을 하드코딩해서 TEST 데이터로 활용한 상태입니다.
* Trasaction 컴포넌트에 props로 내려온 거래내역이 잘 렌더링 되는지에 대한 테스트코드를 추가했습니다.
* 거래내역들을 일자별로 분류해서 Map 형태로 반환하는 로직을 util 함수로 분리하고 단위테스트를 추가했습니다.

## 체크리스트
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지