### PR TITLE
[Sprint 1] Responsive fix - 반응형 요소 설정 수정

### DIFF
--- a/frontend/src/components/Header/style.js
+++ b/frontend/src/components/Header/style.js
@@ -5,7 +5,7 @@ import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
 
 export const Wrapper = styled.div`
     width: 100vw;
-    min-width: 169px;
+    min-width: 228px;
     height: 100px;
 
     display: flex;

--- a/frontend/src/components/Summary/style.js
+++ b/frontend/src/components/Summary/style.js
@@ -44,6 +44,10 @@ export const SummaryBox = styled.div`
         ({ theme }) =>
             theme.color[props.color]};
 
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         margin: 0px;
 

--- a/frontend/src/components/Transaction/style.js
+++ b/frontend/src/components/Transaction/style.js
@@ -79,13 +79,13 @@ export const Content = styled.span`
     width: 70%;
     padding-left: 10px;
 
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 100%;
         max-width: 100%;
-
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 `;
 
@@ -93,6 +93,10 @@ export const Method = styled.span`
     width: 30%;
 
     color: ${({ theme }) => theme.color.gray};
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 100%;
@@ -106,14 +110,13 @@ export const Cost = styled.span`
     width: 25%;
 
     text-align: right;
-
     font-weight: bold;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         max-width: 100px;
-
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
     }
 `;

--- a/frontend/src/pages/Main/style.js
+++ b/frontend/src/pages/Main/style.js
@@ -5,6 +5,7 @@ import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
 export const MainWrapper = styled.div`
     width: calc(100vw - 15px);
     height: calc(100vh - 125px);
+    min-width: 228px;
 
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## 구현한 내용
* 기존의 요약정보의 금액이나, 결제수단의 내용이 길어져서 공간을 벗어나는 경우가 있었습니다.
* 해당 부분에 대해서는 관련된 css 설정을 통해 수정했습니다. (https://github.com/jhLim97/account-book/pull/44/commits/ca39713242c307a922b201017f8ada64834918df)
* 추가적으로 앱의 최소넓이는 228px로 설정했습니다. (상단 헤더가 깨지지 않는 최소 넓이 기준)

## 체크리스트
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지