### PR TITLE
[Sprint 1] 거래내역 수정, 삭제 모달 요소 중 카테고리, 결제수단에 대한 드롭다운 UI 구현 #5

### DIFF
--- a/backend/service/transaction-service.js
+++ b/backend/service/transaction-service.js
@@ -9,7 +9,7 @@ const getUserId = async (nickname) => {
 const getTransactions = async (year, month, nickname) => {
     const [userId] = await getUserId(nickname);
     const sql = `
-        SELECT category.name AS category, color, content, method.name AS method, transaction.sign AS sign, cost, DATE_FORMAT(date, '%Y-%m-%d') AS date 
+        SELECT transaction.id AS id, category.name AS category, color, content, method.name AS method, transaction.sign AS sign, cost, DATE_FORMAT(date, '%Y-%m-%d') AS date 
         FROM transaction 
         LEFT JOIN method ON transaction.mid = method.id 
         LEFT JOIN category ON transaction.cid = category.id 

--- a/frontend/public/assets/delete-button.svg
+++ b/frontend/public/assets/delete-button.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 4L4 12" stroke="#F45452" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 4L12 12" stroke="#F45452" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/Dropdown/index.jsx
+++ b/frontend/src/components/Dropdown/index.jsx
@@ -8,7 +8,7 @@ const Dropdown = ({ name, data, active, changeHandler, deleteHandler, createHand
     const items = data.map((_data) => (
         <Item key={nanoid()} onClick={changeHandler}>
             <span>{_data.name}</span>
-            {deleteHandler && <img src={deleteImg} onClick={deleteHandler} />}
+            {deleteHandler && <img src={deleteImg} onClick={deleteHandler} alt="delete" />}
         </Item>
     ));
 

--- a/frontend/src/components/Dropdown/index.jsx
+++ b/frontend/src/components/Dropdown/index.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { nanoid } from 'nanoid';
+
+import deleteImg from '../../../public/assets/delete-button.svg';
+import { Wrapper, Item } from './style';
+
+const Dropdown = ({ data, active, changeHandler, deleteHandler, createHandler }) => {
+    const items = data.map((_data) => (
+        <Item key={nanoid()} onClick={changeHandler}>
+            <span>{_data.name}</span>
+            {deleteHandler && <img src={deleteImg} onClick={deleteHandler} />}
+        </Item>
+    ));
+
+    return (
+        <Wrapper active={active}>
+            {items}
+            {createHandler && (
+                <Item>
+                    <button type="button" aria-label="addCategory" onClick={createHandler}>
+                        추가하기
+                    </button>
+                </Item>
+            )}
+        </Wrapper>
+    );
+};
+
+export default Dropdown;

--- a/frontend/src/components/Dropdown/index.jsx
+++ b/frontend/src/components/Dropdown/index.jsx
@@ -4,7 +4,7 @@ import { nanoid } from 'nanoid';
 import deleteImg from '../../../public/assets/delete-button.svg';
 import { Wrapper, Item } from './style';
 
-const Dropdown = ({ data, active, changeHandler, deleteHandler, createHandler }) => {
+const Dropdown = ({ name, data, active, changeHandler, deleteHandler, createHandler }) => {
     const items = data.map((_data) => (
         <Item key={nanoid()} onClick={changeHandler}>
             <span>{_data.name}</span>
@@ -13,7 +13,7 @@ const Dropdown = ({ data, active, changeHandler, deleteHandler, createHandler })
     ));
 
     return (
-        <Wrapper active={active}>
+        <Wrapper active={active} name={name}>
             {items}
             {createHandler && (
                 <Item>

--- a/frontend/src/components/Dropdown/style.js
+++ b/frontend/src/components/Dropdown/style.js
@@ -7,6 +7,8 @@ export const Wrapper = styled.ul`
     margin-top: 60px;
     position: absolute;
     width: 250px;
+    max-height: 120px;
+    overflow-y: scroll;
 
     visibility: ${(props) => (props.active ? 'none' : 'hidden')};
 
@@ -15,7 +17,7 @@ export const Wrapper = styled.ul`
     box-shadow: ${({ theme }) => theme.shadow.pale};
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        margin-top: ${(props) => (props.name === 'category' ? '47vh' : '73.3vh')};
+        margin-top: ${(props) => (props.name === 'category' ? '47.2vh' : '73.3vh')};
         width: 80vw;
         top: 0;
     }

--- a/frontend/src/components/Dropdown/style.js
+++ b/frontend/src/components/Dropdown/style.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
+
 export const Wrapper = styled.ul`
     z-index: 3;
     margin-top: 60px;
@@ -11,6 +13,12 @@ export const Wrapper = styled.ul`
     border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
     background-color: ${({ theme }) => theme.color.white};
     box-shadow: ${({ theme }) => theme.shadow.pale};
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        margin-top: ${(props) => (props.name === 'category' ? '47vh' : '73.3vh')};
+        width: 80vw;
+        top: 0;
+    }
 `;
 
 export const Item = styled.li`
@@ -35,5 +43,9 @@ export const Item = styled.li`
         transform: scale(1.01);
         background: ${({ theme }) => theme.color.brigtenL2Gray};
         cursor: pointer;
+    }
+
+    &:last-child {
+        border-bottom: none;
     }
 `;

--- a/frontend/src/components/Dropdown/style.js
+++ b/frontend/src/components/Dropdown/style.js
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.ul`
+    z-index: 3;
+    margin-top: 60px;
+    position: absolute;
+    width: 250px;
+
+    visibility: ${(props) => (props.active ? 'none' : 'hidden')};
+
+    border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
+    background-color: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.shadow.pale};
+`;
+
+export const Item = styled.li`
+    margin: 0 auto;
+    padding: 10px 0;
+    width: 90%;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    border-bottom: 1px solid #d7d7d7;
+    font-weight: normal;
+
+    & > button {
+        border-bottom: none;
+        font-weight: bold;
+    }
+
+    &:hover {
+        transform: scale(1.01);
+        background: ${({ theme }) => theme.color.brigtenL2Gray};
+        cursor: pointer;
+    }
+`;

--- a/frontend/src/components/Dropdown/test.js
+++ b/frontend/src/components/Dropdown/test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '../../test-utils';
+import '@testing-library/jest-dom';
+
+import Dropdown from '.';
+
+const TEST_DATA = [
+    { id: 1, name: '일상/생활', color: '#817DCE', sign: '-' },
+    { id: 2, name: '식비', color: '#817DCE', sign: '-' },
+    { id: 3, name: '카페', color: '#817DCE', sign: '-' },
+    { id: 4, name: '교통', color: '#817DCE', sign: '-' },
+];
+
+describe('TransactionUpateForm 테스트', () => {
+    it('item 들을 정상적으로 표시한다.', () => {
+        render(<Dropdown data={TEST_DATA} active={true} />);
+
+        const items = screen.getAllByRole('listitem');
+
+        expect(items).toHaveLength(TEST_DATA.length);
+        items.forEach((item, index) => {
+            expect(item).toHaveTextContent(TEST_DATA[index].name);
+        });
+    });
+
+    it('props에 deleteHandler가 있는 경우에 삭제이미지가 item 개수만큼 표시한다.', () => {
+        render(<Dropdown data={TEST_DATA} active={true} />);
+        const notExistedDeleteImg = screen.queryAllByAltText('delete');
+        expect(notExistedDeleteImg).toHaveLength(0);
+
+        const deleteHandler = jest.fn();
+        render(<Dropdown data={TEST_DATA} active={true} deleteHandler={deleteHandler} />);
+        const deleteImg = screen.getAllByAltText('delete');
+        expect(deleteImg).toHaveLength(TEST_DATA.length);
+    });
+
+    it('props에 createHandler 있는 경우에 추가하기 버튼이 표시한다.', () => {
+        render(<Dropdown data={TEST_DATA} active={true} />);
+        const notExistedAddButton = screen.queryByRole('button');
+        expect(notExistedAddButton).not.toBeInTheDocument();
+
+        const createHandler = jest.fn();
+        render(<Dropdown data={TEST_DATA} active={true} createHandler={createHandler} />);
+        const addButton = screen.getByRole('button');
+        expect(addButton).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -77,7 +77,6 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         console.log('삭제하기');
     };
 
-    // TODO 입력폼들은 별도의 컴포넌트 만들어서 재활용 하기
     return (
         <Wrapper aria-label="transactionUpdate" onSubmit={handleUpdateSubmit}>
             <Element>
@@ -126,6 +125,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     onClick={categoryActiveToggle}
                 />
                 <Dropdown
+                    name="category"
                     data={categoryDummy}
                     active={activeCategory}
                     changeHandler={changeCategory}
@@ -155,7 +155,12 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     value={inputs.method}
                     onClick={methodActiveToggle}
                 />
-                <Dropdown data={methodDummy} active={activeMethod} changeHandler={changeMethod} />
+                <Dropdown
+                    name="method"
+                    data={methodDummy}
+                    active={activeMethod}
+                    changeHandler={changeMethod}
+                />
             </Element>
             <Element>
                 <label htmlFor="cost">금액</label>

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -1,9 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import back from '../../../public/assets/back-button.svg';
-import { Wrapper, Element, BackImg, Input, ButtonContainer, DecisionButton } from './style';
+import {
+    Wrapper,
+    CostType,
+    TypeButton,
+    Element,
+    BackImg,
+    Input,
+    ButtonContainer,
+    DecisionButton,
+} from './style';
 
 const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) => {
+    const initCostType = transaction.sign === '+' ? 'income' : 'expenditure';
+    const [costType, setCostType] = useState(initCostType);
+
     const shapedForm = (elements) => {
         const data = {};
         Array.from(elements).forEach((element) => {
@@ -18,7 +30,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         e.preventDefault();
 
         const form = e.target;
-        const data = shapedForm(form.elements);
+        const sign = costType === 'income' ? '+' : '-';
+        const data = { ...shapedForm(form.elements), sign };
         onUpdate(data);
     };
 
@@ -29,6 +42,24 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     <BackImg src={back} />
                 </button>
             </Element>
+            <CostType>
+                <TypeButton
+                    type="button"
+                    aria-label="income"
+                    active={costType === 'income'}
+                    onClick={() => setCostType('income')}
+                >
+                    수입
+                </TypeButton>
+                <TypeButton
+                    type="button"
+                    aria-label="expenditure"
+                    active={costType === 'expenditure'}
+                    onClick={() => setCostType('expenditure')}
+                >
+                    지출
+                </TypeButton>
+            </CostType>
             <Element>
                 <label htmlFor="date">날짜</label>
                 <Input

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 
+import Dropdown from '../Dropdown';
 import back from '../../../public/assets/back-button.svg';
-import deleteImg from '../../../public/assets/delete-button.svg';
 import {
     Wrapper,
     CostType,
@@ -13,6 +12,19 @@ import {
     ButtonContainer,
     DecisionButton,
 } from './style';
+
+const categoryDummy = [
+    { id: 1, name: '일상/생활', color: '#817DCE', sign: '-' },
+    { id: 2, name: '식비', color: '#817DCE', sign: '-' },
+    { id: 3, name: '카페', color: '#817DCE', sign: '-' },
+    { id: 4, name: '교통', color: '#817DCE', sign: '-' },
+];
+
+const methodDummy = [
+    { id: 1, name: '카카오페이' },
+    { id: 2, name: '현금' },
+    { id: 3, name: '토스' },
+];
 
 const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) => {
     const [activeCategory, setActiveCategory] = useState(false);
@@ -65,6 +77,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         console.log('삭제하기');
     };
 
+    // TODO 입력폼들은 별도의 컴포넌트 만들어서 재활용 하기
     return (
         <Wrapper aria-label="transactionUpdate" onSubmit={handleUpdateSubmit}>
             <Element>
@@ -112,29 +125,13 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     value={inputs.category}
                     onClick={categoryActiveToggle}
                 />
-                <DropdownContainer active={activeCategory}>
-                    <Item onClick={changeCategory}>
-                        <span>일상/생활</span>
-                        <img src={deleteImg} onClick={deleteCategory} />
-                    </Item>
-                    <Item onClick={changeCategory}>
-                        <span>식비</span>
-                        <img src={deleteImg} onClick={deleteCategory} />
-                    </Item>
-                    <Item onClick={changeCategory}>
-                        <span>카페</span>
-                        <img src={deleteImg} onClick={deleteCategory} />
-                    </Item>
-                    <Item onClick={changeCategory}>
-                        <span>교통</span>
-                        <img src={deleteImg} onClick={deleteCategory} />
-                    </Item>
-                    <Item>
-                        <button type="button" aria-label="addCategory">
-                            추가하기
-                        </button>
-                    </Item>
-                </DropdownContainer>
+                <Dropdown
+                    data={categoryDummy}
+                    active={activeCategory}
+                    changeHandler={changeCategory}
+                    deleteHandler={deleteCategory}
+                    createHandler={() => console.log('생성로직')}
+                />
             </Element>
             <Element>
                 <label htmlFor="content">내용</label>
@@ -158,17 +155,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     value={inputs.method}
                     onClick={methodActiveToggle}
                 />
-                <DropdownContainer active={activeMethod}>
-                    <Item onClick={changeMethod}>
-                        <span>카카오페이</span>
-                    </Item>
-                    <Item onClick={changeMethod}>
-                        <span>현금</span>
-                    </Item>
-                    <Item onClick={changeMethod}>
-                        <span>토스</span>
-                    </Item>
-                </DropdownContainer>
+                <Dropdown data={methodDummy} active={activeMethod} changeHandler={changeMethod} />
             </Element>
             <Element>
                 <label htmlFor="cost">금액</label>
@@ -194,41 +181,3 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
 };
 
 export default TransactionUpdateForm;
-
-const DropdownContainer = styled.ul`
-    z-index: 3;
-    margin-top: 60px;
-    position: absolute;
-    width: 250px;
-
-    visibility: ${(props) => (props.active ? 'none' : 'hidden')};
-
-    border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
-    background-color: ${({ theme }) => theme.color.white};
-    box-shadow: ${({ theme }) => theme.shadow.pale};
-`;
-
-const Item = styled.li`
-    margin: 0 auto;
-    padding: 10px 0;
-    width: 90%;
-
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-
-    border-bottom: 1px solid #d7d7d7;
-    font-weight: normal;
-
-    & > button {
-        border-bottom: none;
-        font-weight: bold;
-    }
-
-    &:hover {
-        transform: scale(1.01);
-        background: ${({ theme }) => theme.color.brigtenL2Gray};
-        cursor: pointer;
-    }
-`;

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 
 import back from '../../../public/assets/back-button.svg';
+import deleteImg from '../../../public/assets/delete-button.svg';
 import {
     Wrapper,
     CostType,
@@ -13,26 +15,48 @@ import {
 } from './style';
 
 const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) => {
-    const initCostType = transaction.sign === '+' ? 'income' : 'expenditure';
-    const [costType, setCostType] = useState(initCostType);
-
-    const shapedForm = (elements) => {
-        const data = {};
-        Array.from(elements).forEach((element) => {
-            if (element.value) {
-                data[element.id] = element.value;
-            }
-        });
-        return data;
-    };
+    const [activeDropdown, setActiveDropdown] = useState(false);
+    const [inputs, setInputs] = useState(transaction);
 
     const handleUpdateSubmit = (e) => {
         e.preventDefault();
 
-        const form = e.target;
-        const sign = costType === 'income' ? '+' : '-';
-        const data = { ...shapedForm(form.elements), sign };
+        const data = inputs;
         onUpdate(data);
+    };
+
+    const changeActiveToggle = () => {
+        setActiveDropdown((prev) => !prev);
+    };
+
+    const changeSign = (sign) => {
+        setInputs((prev) => ({ ...prev, sign }));
+    };
+
+    const changeDate = (e) => {
+        setInputs((prev) => ({ ...prev, date: e.target.value }));
+    };
+
+    const changeCategory = (e) => {
+        setInputs((prev) => ({ ...prev, category: e.target.innerText }));
+        changeActiveToggle();
+    };
+
+    const changeContent = (e) => {
+        setInputs((prev) => ({ ...prev, content: e.target.value }));
+    };
+
+    const changeMethod = (e) => {
+        setInputs((prev) => ({ ...prev, method: e.target.value }));
+    };
+
+    const changeCost = (e) => {
+        setInputs((prev) => ({ ...prev, cost: e.target.value }));
+    };
+
+    const deleteCategory = (e) => {
+        e.stopPropagation();
+        console.log('삭제하기');
     };
 
     return (
@@ -46,16 +70,16 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                 <TypeButton
                     type="button"
                     aria-label="income"
-                    active={costType === 'income'}
-                    onClick={() => setCostType('income')}
+                    active={inputs.sign === '+'}
+                    onClick={() => changeSign('+')}
                 >
                     수입
                 </TypeButton>
                 <TypeButton
                     type="button"
                     aria-label="expenditure"
-                    active={costType === 'expenditure'}
-                    onClick={() => setCostType('expenditure')}
+                    active={inputs.sign === '-'}
+                    onClick={() => changeSign('-')}
                 >
                     지출
                 </TypeButton>
@@ -67,7 +91,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     id="date"
                     placeholder="YYYY-MM-DD"
                     autoComplete="off"
-                    defaultValue={transaction.date}
+                    value={inputs.date}
+                    onChange={changeDate}
                 />
             </Element>
             <Element>
@@ -77,8 +102,31 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     id="category"
                     placeholder="입력하세요."
                     autoComplete="off"
-                    defaultValue={transaction.category}
+                    readOnly
+                    value={inputs.category}
+                    onClick={changeActiveToggle}
                 />
+                <DropdownContainer active={activeDropdown}>
+                    <Item onClick={changeCategory}>
+                        <span>일상/생활</span>
+                        <img src={deleteImg} onClick={deleteCategory} />
+                    </Item>
+                    <Item onClick={changeCategory}>
+                        <span>식비</span>
+                        <img src={deleteImg} onClick={deleteCategory} />
+                    </Item>
+                    <Item onClick={changeCategory}>
+                        <span>카페</span>
+                        <img src={deleteImg} onClick={deleteCategory} />
+                    </Item>
+                    <Item onClick={changeCategory}>
+                        <span>교통</span>
+                        <img src={deleteImg} onClick={deleteCategory} />
+                    </Item>
+                    <Item>
+                        <span>추가하기</span>
+                    </Item>
+                </DropdownContainer>
             </Element>
             <Element>
                 <label htmlFor="content">내용</label>
@@ -87,7 +135,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     id="content"
                     placeholder="입력하세요."
                     autoComplete="off"
-                    defaultValue={transaction.content}
+                    value={inputs.content}
+                    onChange={changeContent}
                 />
             </Element>
             <Element>
@@ -97,7 +146,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     id="method"
                     placeholder="입력하세요."
                     autoComplete="off"
-                    defaultValue={transaction.method}
+                    value={inputs.method}
+                    onChange={changeMethod}
                 />
             </Element>
             <Element>
@@ -107,7 +157,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     id="cost"
                     placeholder="숫자만 기입하세요.(ex 3000)"
                     autoComplete="off"
-                    defaultValue={transaction.cost}
+                    value={inputs.cost}
+                    onChange={changeCost}
                 />
             </Element>
             <ButtonContainer>
@@ -123,3 +174,41 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
 };
 
 export default TransactionUpdateForm;
+
+const DropdownContainer = styled.ul`
+    z-index: 3;
+    margin-top: 60px;
+    position: absolute;
+    width: 250px;
+
+    visibility: ${(props) => (props.active ? 'none' : 'hidden')};
+
+    border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
+    background-color: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.shadow.pale};
+`;
+
+const Item = styled.li`
+    margin: 0 auto;
+    padding: 10px 0;
+    width: 90%;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    border-bottom: 1px solid #d7d7d7;
+    font-weight: normal;
+
+    &:last-child {
+        border-bottom: none;
+        font-weight: bold;
+    }
+
+    &:hover {
+        transform: scale(1.01);
+        background: ${({ theme }) => theme.color.brigtenL2Gray};
+        cursor: pointer;
+    }
+`;

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -15,7 +15,8 @@ import {
 } from './style';
 
 const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) => {
-    const [activeDropdown, setActiveDropdown] = useState(false);
+    const [activeCategory, setActiveCategory] = useState(false);
+    const [activeMethod, setActiveMethod] = useState(false);
     const [inputs, setInputs] = useState(transaction);
 
     const handleUpdateSubmit = (e) => {
@@ -25,8 +26,12 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         onUpdate(data);
     };
 
-    const changeActiveToggle = () => {
-        setActiveDropdown((prev) => !prev);
+    const categoryActiveToggle = () => {
+        setActiveCategory((prev) => !prev);
+    };
+
+    const methodActiveToggle = () => {
+        setActiveMethod((prev) => !prev);
     };
 
     const changeSign = (sign) => {
@@ -39,7 +44,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
 
     const changeCategory = (e) => {
         setInputs((prev) => ({ ...prev, category: e.target.innerText }));
-        changeActiveToggle();
+        categoryActiveToggle();
     };
 
     const changeContent = (e) => {
@@ -47,7 +52,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
     };
 
     const changeMethod = (e) => {
-        setInputs((prev) => ({ ...prev, method: e.target.value }));
+        setInputs((prev) => ({ ...prev, method: e.target.innerText }));
+        methodActiveToggle();
     };
 
     const changeCost = (e) => {
@@ -104,9 +110,9 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     autoComplete="off"
                     readOnly
                     value={inputs.category}
-                    onClick={changeActiveToggle}
+                    onClick={categoryActiveToggle}
                 />
-                <DropdownContainer active={activeDropdown}>
+                <DropdownContainer active={activeCategory}>
                     <Item onClick={changeCategory}>
                         <span>일상/생활</span>
                         <img src={deleteImg} onClick={deleteCategory} />
@@ -124,7 +130,9 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                         <img src={deleteImg} onClick={deleteCategory} />
                     </Item>
                     <Item>
-                        <span>추가하기</span>
+                        <button type="button" aria-label="addCategory">
+                            추가하기
+                        </button>
                     </Item>
                 </DropdownContainer>
             </Element>
@@ -146,9 +154,21 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     id="method"
                     placeholder="입력하세요."
                     autoComplete="off"
+                    readOnly
                     value={inputs.method}
-                    onChange={changeMethod}
+                    onClick={methodActiveToggle}
                 />
+                <DropdownContainer active={activeMethod}>
+                    <Item onClick={changeMethod}>
+                        <span>카카오페이</span>
+                    </Item>
+                    <Item onClick={changeMethod}>
+                        <span>현금</span>
+                    </Item>
+                    <Item onClick={changeMethod}>
+                        <span>토스</span>
+                    </Item>
+                </DropdownContainer>
             </Element>
             <Element>
                 <label htmlFor="cost">금액</label>
@@ -201,7 +221,7 @@ const Item = styled.li`
     border-bottom: 1px solid #d7d7d7;
     font-weight: normal;
 
-    &:last-child {
+    & > button {
         border-bottom: none;
         font-weight: bold;
     }

--- a/frontend/src/components/TransactionUpdateForm/style.js
+++ b/frontend/src/components/TransactionUpdateForm/style.js
@@ -88,7 +88,7 @@ export const Input = styled.input`
     padding: 10px;
 
     border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
-    border-radius: 10px;
+    border-radius: 5px;
     background: ${({ theme }) => theme.color.whiteSmoke};
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {

--- a/frontend/src/components/TransactionUpdateForm/style.js
+++ b/frontend/src/components/TransactionUpdateForm/style.js
@@ -8,6 +8,7 @@ export const Wrapper = styled.form`
 
     width: 700px;
     height: 500px;
+    min-width: 228px;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -33,6 +34,34 @@ export const Wrapper = styled.form`
     }
 `;
 
+export const CostType = styled.div`
+    width: 250px;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 80vw;
+        height: 8vh;
+    }
+`;
+
+export const TypeButton = styled.button`
+    margin: 0px 5px 5px 0px;
+    width: 57px;
+    height: 37px;
+
+    font-weight: bold;
+    border: 2px solid
+        ${({ theme }) =>
+            (props) =>
+                props.active ? theme.color.mint : theme.color.brigtenL1Gray};
+    color: ${({ theme }) =>
+        (props) =>
+            props.active ? theme.color.mint : theme.color.brigtenL1Gray};
+`;
+
 export const Element = styled.div`
     margin-bottom: 10px;
     width: 250px;
@@ -44,7 +73,7 @@ export const Element = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 12vh;
+        height: 11vh;
 
         justify-content: center;
     }
@@ -68,7 +97,6 @@ export const Input = styled.input`
 `;
 
 export const ButtonContainer = styled.div`
-    padding-left: 0px;
     width: 250px;
 
     display: flex;
@@ -77,7 +105,7 @@ export const ButtonContainer = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 12vh;
+        height: 11vh;
     }
 `;
 

--- a/frontend/src/components/TransactionUpdateForm/test.js
+++ b/frontend/src/components/TransactionUpdateForm/test.js
@@ -9,6 +9,7 @@ const TEST_DATA = {
     method: '현금',
     cost: '5700',
     date: '2022-01-28',
+    sign: '-',
 };
 
 describe('TransactionUpateForm 테스트', () => {
@@ -23,6 +24,8 @@ describe('TransactionUpateForm 테스트', () => {
         );
 
         const backButton = screen.getByRole('button', { name: 'back' });
+        const incomeButton = screen.getByRole('button', { name: 'income' });
+        const expenditureButton = screen.getByRole('button', { name: 'expenditure' });
         const dateInput = screen.getByLabelText('날짜');
         const categoryInput = screen.getByLabelText('카테고리');
         const contentInput = screen.getByLabelText('내용');
@@ -32,6 +35,8 @@ describe('TransactionUpateForm 테스트', () => {
         const updateButton = screen.getByRole('button', { name: '수정' });
 
         expect(backButton).toBeInTheDocument();
+        expect(incomeButton).toBeInTheDocument();
+        expect(expenditureButton).toBeInTheDocument();
         expect(dateInput.value).toEqual(TEST_DATA['date']);
         expect(categoryInput.value).toEqual(TEST_DATA['category']);
         expect(contentInput.value).toEqual(TEST_DATA['content']);


### PR DESCRIPTION
### PC 버전
![image](https://user-images.githubusercontent.com/67899069/152791104-4ea819c6-3f64-4f8a-9cc8-722c4fb10684.png)

### 모바일 버전(iPhone SE)
![image](https://user-images.githubusercontent.com/67899069/152790909-531cb2a4-172e-4325-bced-4819088e6183.png)![image](https://user-images.githubusercontent.com/67899069/152790951-ec7b8149-7c67-48b7-bca7-1670403efda2.png)


## 구현한 내용
* 거래내역 DB 조회 시 해당 거래의 id도 반환하도록 쿼리를 수정했습니다.
* 거래내역 수정, 삭제 UI에 수입 및 지출관련 버튼을 추가했습니다.
* 카테고리, 결제수단에 대한 드롭다운을 구현했습니다.
    * 카테고리의 경우 삭제, 추가하기 버튼이 존재합니다.
    * 결제수단의 경우 item만 제공합니다.

## 어려웠던 점
1. 여러개의 모달이 필요한 경우 상태관리
* 현재 거래내역 수정 및 삭제 모달과 그 안에 2개의 드롭다운 모달이 필요한 상태입니다.
* 이에 따라 이벤트 핸들러와 열고 닫는 로직을 관리하기 위해서 이러한 모달들을 필요로 하는 컴포넌트가 비대해진 상태입니다.
* 따라서, 모달에 대한 관리를 전역에서 처리할 필요가 있어보입니다.

## 체크리스트
- [x] PC, 모바일 버전에 맞춰서 반응형 웹 구현하기
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지