### PR TITLE
[Sprint 1] 결제수단(Method) API 구현 #11

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ import cors from 'cors';
 import userRouter from './routes/user.js';
 import transactionRouter from './routes/transaction.js';
 import categoryRouter from './routes/category.js';
+import methodRouter from './routes/method.js';
 
 const app = express();
 
@@ -23,5 +24,6 @@ app.use(cookieParser());
 app.use('/api/user', userRouter);
 app.use('/api/transactions', transactionRouter);
 app.use('/api/categories', categoryRouter);
+app.use('/api/methods', methodRouter);
 
 export default app;

--- a/backend/controller/method-controller.js
+++ b/backend/controller/method-controller.js
@@ -1,0 +1,19 @@
+import MethodService from '../service/method-service.js';
+
+const getMethods = async (req, res) => {
+    try {
+        const result = await MethodService.getMethods();
+
+        res.status(200).json({
+            data: result,
+        });
+    } catch (e) {
+        res.status(400).json({
+            message: e.message,
+        });
+    }
+};
+
+export default {
+    getMethods,
+};

--- a/backend/controller/transaction-controller.js
+++ b/backend/controller/transaction-controller.js
@@ -9,7 +9,6 @@ const getTransactions = async (req, res) => {
             data: result,
         });
     } catch (e) {
-        console.log(e.message);
         res.status(400).json({
             message: e.message,
         });

--- a/backend/routes/method.js
+++ b/backend/routes/method.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import MethodController from '../controller/method-controller.js';
+
+const router = express.Router();
+
+router.get('/', MethodController.getMethods);
+
+export default router;

--- a/backend/service/category-service.js
+++ b/backend/service/category-service.js
@@ -11,7 +11,6 @@ const getCategories = async () => {
         };
         return result;
     } catch (e) {
-        console.log(e);
         return {
             status: 'error',
         };

--- a/backend/service/method-service.js
+++ b/backend/service/method-service.js
@@ -1,0 +1,11 @@
+import pool from '../database/connection.js';
+
+const getMethods = async () => {
+    const sql = `SELECT id, name FROM method`;
+    const [row] = await pool.query(sql);
+    return row;
+};
+
+export default {
+    getMethods,
+};

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import Dropdown from '../Dropdown';
+import { methodState } from '../../recoil/method/atom';
 import back from '../../../public/assets/back-button.svg';
 import {
     Wrapper,
@@ -30,6 +32,8 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
     const [activeCategory, setActiveCategory] = useState(false);
     const [activeMethod, setActiveMethod] = useState(false);
     const [inputs, setInputs] = useState(transaction);
+
+    const methods = useRecoilValue(methodState);
 
     const handleUpdateSubmit = (e) => {
         e.preventDefault();
@@ -157,7 +161,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                 />
                 <Dropdown
                     name="method"
-                    data={methodDummy}
+                    data={methods}
                     active={activeMethod}
                     changeHandler={changeMethod}
                 />

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -22,12 +22,6 @@ const categoryDummy = [
     { id: 4, name: '교통', color: '#817DCE', sign: '-' },
 ];
 
-const methodDummy = [
-    { id: 1, name: '카카오페이' },
-    { id: 2, name: '현금' },
-    { id: 3, name: '토스' },
-];
-
 const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) => {
     const [activeCategory, setActiveCategory] = useState(false);
     const [activeMethod, setActiveMethod] = useState(false);

--- a/frontend/src/lib/method.js
+++ b/frontend/src/lib/method.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const instance = axios.create({
+    baseURL: process.env.API_SERVER + '/methods',
+});
+
+export const getMethods = async () => {
+    try {
+        const response = await instance.get('/');
+        return response.data;
+    } catch (e) {
+        // TODO 에러 발생 알림창 띄우기
+        console.log(e);
+    }
+};

--- a/frontend/src/pages/Main/hooks.js
+++ b/frontend/src/pages/Main/hooks.js
@@ -1,0 +1,15 @@
+import { useSetRecoilState } from 'recoil';
+
+import { getMethods } from '../../lib/method';
+import { methodState } from '../../recoil/method/atom';
+
+export const usefetchMethods = () => {
+    const setMethod = useSetRecoilState(methodState);
+
+    const fetchMethods = async () => {
+        const result = await getMethods();
+        result && setMethod(result.data);
+    };
+
+    return [fetchMethods];
+};

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -1,12 +1,18 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 
+import { usefetchMethods } from './hooks';
 import Header from '../../components/Header';
 import Summary from '../../components/Summary';
 import Transactions from '../../components/Transactions';
-
 import { MainWrapper } from './style';
 
 const Main = () => {
+    const [fetchMethods] = usefetchMethods();
+
+    useEffect(() => {
+        fetchMethods();
+    }, []);
+
     return (
         <>
             <Header current={'main'} />

--- a/frontend/src/recoil/method/atom.js
+++ b/frontend/src/recoil/method/atom.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const methodState = atom({
+    key: 'methodState',
+    default: [],
+});


### PR DESCRIPTION
## 구현한 내용
* 결제수단을 제공하는 API를 구현했습니다.
    * 결제수단을 DB에서 불러오기 위한 로직을 구현했습니다.
    * 경로를 미들웨어에 등록하고 라우터, 컨트롤러, 서비스로직을 구현했습니다.
* 프론트에서 요청해서 받은 결제수단을 전역으로 관리하는 recoil atom 파일을 생성했습니다.
* 기존의 더미데이터로 구현된 결제수단 렌더링 로직을, 실제 데이터를 기반으로 변경했습니다.

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지