### PR TITLE
[Sprint 1] 거래내역 추가 버튼 및 모달 구현 #5

### DIFF
--- a/frontend/public/assets/fab-button.svg
+++ b/frontend/public/assets/fab-button.svg
@@ -1,0 +1,5 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="28" cy="28" r="28" fill="#045D8B"/>
+<path d="M28 21V35" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 28H35" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/public/assets/fab-button.svg
+++ b/frontend/public/assets/fab-button.svg
@@ -1,5 +1,5 @@
 <svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="28" cy="28" r="28" fill="#045D8B"/>
+<circle cx="28" cy="28" r="28" fill="#06d6a0"/>
 <path d="M28 21V35" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M21 28H35" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/src/components/DailyTransaction/style.js
+++ b/frontend/src/components/DailyTransaction/style.js
@@ -19,8 +19,6 @@ export const DailyInfo = styled.div`
     white-space: nowrap;
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        margin: 0px 15px;
-
         font-size: ${({ theme }) => theme.fontSize.mini};
     }
 `;

--- a/frontend/src/components/Transaction/index.jsx
+++ b/frontend/src/components/Transaction/index.jsx
@@ -8,7 +8,7 @@ const Transaction = ({ transaction }) => {
     const { openModal } = useModal();
 
     return (
-        <Wrapper onClick={() => openModal('transaction', transaction)}>
+        <Wrapper onClick={() => openModal('updateTransaction', transaction)}>
             <OuterBox>
                 <Category data-testid="category">{transaction.category || '미분류'}</Category>
                 <InnerBox>

--- a/frontend/src/components/Transaction/style.js
+++ b/frontend/src/components/Transaction/style.js
@@ -19,10 +19,6 @@ export const Wrapper = styled.li`
         background: ${({ theme }) => theme.color.brigtenL2Gray};
         cursor: pointer;
     }
-
-    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        margin: 0px 15px;
-    }
 `;
 
 export const OuterBox = styled.div`

--- a/frontend/src/components/TransactionCreateForm/hooks.js
+++ b/frontend/src/components/TransactionCreateForm/hooks.js
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { useModal } from '../../hooks/useModal';
+import { methodState } from '../../recoil/method/atom';
+import { categoryState } from '../../recoil/category/atom';
+import { deleteCategory } from '../../lib/category';
+
+export const useCreateForm = (transaction, onCreate) => {
+    const [activeCategory, setActiveCategory] = useState(false);
+    const [activeMethod, setActiveMethod] = useState(false);
+    const [inputs, setInputs] = useState(transaction);
+
+    const methods = useRecoilValue(methodState);
+    const [categories, setCategories] = useRecoilState(categoryState);
+
+    const { openModal } = useModal();
+
+    const handleCreateSubmit = (e) => {
+        e.preventDefault();
+        onCreate(inputs);
+    };
+
+    const categoryActiveToggle = () => {
+        setActiveCategory((prev) => !prev);
+    };
+
+    const methodActiveToggle = () => {
+        setActiveMethod((prev) => !prev);
+    };
+
+    const changeSign = (sign) => {
+        setInputs((prev) => ({ ...prev, sign }));
+    };
+
+    const changeDate = (e) => {
+        setInputs((prev) => ({ ...prev, date: e.target.value }));
+    };
+
+    const changeCategory = (e) => {
+        setInputs((prev) => ({ ...prev, category: e.target.innerText }));
+        categoryActiveToggle();
+    };
+
+    const changeContent = (e) => {
+        setInputs((prev) => ({ ...prev, content: e.target.value }));
+    };
+
+    const changeMethod = (e) => {
+        setInputs((prev) => ({ ...prev, method: e.target.innerText }));
+        methodActiveToggle();
+    };
+
+    const changeCost = (e) => {
+        setInputs((prev) => ({ ...prev, cost: e.target.value }));
+    };
+
+    const removeCategory = async (id, e) => {
+        e.stopPropagation();
+        const complete = await deleteCategory(id);
+        complete && setCategories((prev) => prev.filter((_prev) => _prev.id !== id));
+    };
+
+    const openCategoryCreateModal = () => {
+        openModal('createCategory', { sign: '+', name: '', color: '' });
+    };
+
+    return [
+        activeCategory,
+        activeMethod,
+        inputs,
+        methods,
+        categories,
+        handleCreateSubmit,
+        categoryActiveToggle,
+        methodActiveToggle,
+        changeSign,
+        changeDate,
+        changeCategory,
+        changeContent,
+        changeMethod,
+        changeCost,
+        removeCategory,
+        openCategoryCreateModal,
+    ];
+};

--- a/frontend/src/components/TransactionCreateForm/index.jsx
+++ b/frontend/src/components/TransactionCreateForm/index.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+
+import Dropdown from '../Dropdown';
+import back from '../../../public/assets/back-button.svg';
+import { useCreateForm } from './hooks';
+import {
+    Wrapper,
+    CostType,
+    TypeButton,
+    Element,
+    BackImg,
+    Input,
+    ButtonContainer,
+    DecisionButton,
+} from './style';
+
+const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
+    const [
+        activeCategory,
+        activeMethod,
+        inputs,
+        methods,
+        categories,
+        handleCreateSubmit,
+        categoryActiveToggle,
+        methodActiveToggle,
+        changeSign,
+        changeDate,
+        changeCategory,
+        changeContent,
+        changeMethod,
+        changeCost,
+        removeCategory,
+        openCategoryCreateModal,
+    ] = useCreateForm(transaction, onCreate);
+
+    return (
+        <Wrapper aria-label="transactionCreate" onSubmit={handleCreateSubmit}>
+            <Element>
+                <button type="button" aria-label="back" onClick={onCancle}>
+                    <BackImg src={back} />
+                </button>
+            </Element>
+            <CostType>
+                <TypeButton
+                    type="button"
+                    aria-label="income"
+                    active={inputs.sign === '+'}
+                    onClick={() => changeSign('+')}
+                >
+                    수입
+                </TypeButton>
+                <TypeButton
+                    type="button"
+                    aria-label="expenditure"
+                    active={inputs.sign === '-'}
+                    onClick={() => changeSign('-')}
+                >
+                    지출
+                </TypeButton>
+            </CostType>
+            <Element>
+                <label htmlFor="date">날짜</label>
+                <Input
+                    type="text"
+                    id="date"
+                    placeholder="YYYY-MM-DD"
+                    autoComplete="off"
+                    value={inputs.date}
+                    onChange={changeDate}
+                />
+            </Element>
+            <Element>
+                <label htmlFor="category">카테고리</label>
+                <Input
+                    type="text"
+                    id="category"
+                    placeholder="입력하세요."
+                    autoComplete="off"
+                    readOnly
+                    value={inputs.category}
+                    onClick={categoryActiveToggle}
+                />
+                <Dropdown
+                    name="category"
+                    data={categories}
+                    active={activeCategory}
+                    changeHandler={changeCategory}
+                    deleteHandler={removeCategory}
+                    createHandler={openCategoryCreateModal}
+                />
+            </Element>
+            <Element>
+                <label htmlFor="content">내용</label>
+                <Input
+                    type="text"
+                    id="content"
+                    placeholder="입력하세요."
+                    autoComplete="off"
+                    value={inputs.content}
+                    onChange={changeContent}
+                />
+            </Element>
+            <Element>
+                <label htmlFor="method">결제수단</label>
+                <Input
+                    type="text"
+                    id="method"
+                    placeholder="입력하세요."
+                    autoComplete="off"
+                    readOnly
+                    value={inputs.method}
+                    onClick={methodActiveToggle}
+                />
+                <Dropdown
+                    name="method"
+                    data={methods}
+                    active={activeMethod}
+                    changeHandler={changeMethod}
+                />
+            </Element>
+            <Element>
+                <label htmlFor="cost">금액</label>
+                <Input
+                    type="text"
+                    id="cost"
+                    placeholder="숫자만 기입하세요.(ex 3000)"
+                    autoComplete="off"
+                    value={inputs.cost}
+                    onChange={changeCost}
+                />
+            </Element>
+            <ButtonContainer>
+                <DecisionButton type="submit" action="create">
+                    추가
+                </DecisionButton>
+            </ButtonContainer>
+        </Wrapper>
+    );
+};
+
+export default TransactionCreateForm;

--- a/frontend/src/components/TransactionCreateForm/index.jsx
+++ b/frontend/src/components/TransactionCreateForm/index.jsx
@@ -75,7 +75,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
                 <Input
                     type="text"
                     id="category"
-                    placeholder="입력하세요."
+                    placeholder="선택하세요."
                     autoComplete="off"
                     readOnly
                     value={inputs.category}
@@ -106,7 +106,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
                 <Input
                     type="text"
                     id="method"
-                    placeholder="입력하세요."
+                    placeholder="선택하세요."
                     autoComplete="off"
                     readOnly
                     value={inputs.method}

--- a/frontend/src/components/TransactionCreateForm/style.js
+++ b/frontend/src/components/TransactionCreateForm/style.js
@@ -1,0 +1,116 @@
+import styled from 'styled-components';
+
+import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
+
+export const Wrapper = styled.form`
+    position: fixed;
+    z-index: 2;
+
+    width: 700px;
+    height: 500px;
+    min-width: 228px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    background-color: ${({ theme }) => theme.color.white};
+    box-shadow: ${({ theme }) => theme.shadow.thick};
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 100vw;
+        height: 100vh;
+        top: 0;
+        left: 0;
+        transform: none;
+
+        justify-content: space-evenly;
+
+        box-shadow: none;
+    }
+`;
+
+export const CostType = styled.div`
+    width: 250px;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 80vw;
+        height: 8vh;
+    }
+`;
+
+export const TypeButton = styled.button`
+    margin: 0px 5px 5px 0px;
+    width: 57px;
+    height: 37px;
+
+    font-weight: bold;
+    border: 2px solid
+        ${({ theme }) =>
+            (props) =>
+                props.active ? theme.color.mint : theme.color.brigtenL1Gray};
+    color: ${({ theme }) =>
+        (props) =>
+            props.active ? theme.color.mint : theme.color.brigtenL1Gray};
+`;
+
+export const Element = styled.div`
+    margin-bottom: 10px;
+    width: 250px;
+
+    display: flex;
+    flex-direction: column;
+
+    font-weight: bold;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 80vw;
+        height: 11vh;
+
+        justify-content: center;
+    }
+`;
+
+export const BackImg = styled.img`
+    float: left;
+`;
+
+export const Input = styled.input`
+    margin-top: 5px;
+    padding: 10px;
+
+    border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
+    border-radius: 5px;
+    background: ${({ theme }) => theme.color.whiteSmoke};
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        height: 80%;
+    }
+`;
+
+export const ButtonContainer = styled.div`
+    width: 250px;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 80vw;
+        height: 11vh;
+    }
+`;
+
+export const DecisionButton = styled.button`
+    font-weight: bold;
+    font-size: ${({ theme }) => theme.fontSize.default};
+    color: ${({ theme }) => theme.color.blue};
+`;

--- a/frontend/src/components/TransactionCreateForm/test.js
+++ b/frontend/src/components/TransactionCreateForm/test.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen, fireEvent } from '../../test-utils';
+
+import TransactionCreateForm from '.';
+
+const TEST_DATA = {
+    category: '',
+    content: '',
+    method: '',
+    cost: '',
+    date: '',
+    sign: '+',
+};
+
+describe('TransactionCreateForm 테스트', () => {
+    it('기본 요소들이 표시된다.', () => {
+        render(<TransactionCreateForm transaction={TEST_DATA} onCreate={null} onCancle={null} />);
+
+        const backButton = screen.getByRole('button', { name: 'back' });
+        const incomeButton = screen.getByRole('button', { name: 'income' });
+        const expenditureButton = screen.getByRole('button', { name: 'expenditure' });
+        const dateInput = screen.getByLabelText('날짜');
+        const categoryInput = screen.getByLabelText('카테고리');
+        const contentInput = screen.getByLabelText('내용');
+        const methodInput = screen.getByLabelText('결제수단');
+        const costInput = screen.getByLabelText('금액');
+        const createButton = screen.getByRole('button', { name: '추가' });
+
+        expect(backButton).toBeInTheDocument();
+        expect(incomeButton).toBeInTheDocument();
+        expect(expenditureButton).toBeInTheDocument();
+        expect(dateInput.value).toEqual(TEST_DATA['date']);
+        expect(categoryInput.value).toEqual(TEST_DATA['category']);
+        expect(contentInput.value).toEqual(TEST_DATA['content']);
+        expect(methodInput.value).toEqual(TEST_DATA['method']);
+        expect(costInput.value).toEqual(TEST_DATA['cost']);
+        expect(createButton).toBeInTheDocument();
+    });
+
+    it('뒤로가기 버튼을 누르면 onCancle 함수가 호출된다.', () => {
+        const onCancle = jest.fn();
+        render(
+            <TransactionCreateForm transaction={TEST_DATA} onCreate={null} onCancle={onCancle} />,
+        );
+
+        const backButton = screen.getByRole('button', { name: 'back' });
+        fireEvent.click(backButton);
+        expect(onCancle).toHaveBeenCalled();
+    });
+
+    it('추가 버튼을 누르면 form 데이터를 기반으로 onCreate 함수가 호출된다.', () => {
+        const onCreate = jest.fn();
+        render(
+            <TransactionCreateForm transaction={TEST_DATA} onCreate={onCreate} onCancle={null} />,
+        );
+
+        const createButton = screen.getByRole('button', { name: '추가' });
+        fireEvent.click(createButton);
+        expect(onCreate).toHaveBeenCalledWith(TEST_DATA);
+    });
+
+    it('카테고리 input을 누르면 카테고리 Dropdown이 표시된다.', () => {
+        render(<TransactionCreateForm transaction={TEST_DATA} onCreate={null} onCancle={null} />);
+        const categoryDropdown = screen.queryByRole('list', { name: 'category' });
+        expect(categoryDropdown).not.toBeInTheDocument();
+
+        const categoryInput = screen.getByLabelText('카테고리');
+        fireEvent.click(categoryInput);
+
+        const visibleCategoryDropdown = screen.getByRole('list', { name: 'category' });
+        expect(visibleCategoryDropdown).toBeInTheDocument();
+    });
+
+    it('결제수단 input을 누르면 결제수단 Dropdown이 표시된다.', () => {
+        render(<TransactionCreateForm transaction={TEST_DATA} onCreate={null} onCancle={null} />);
+        const methodDropdown = screen.queryByRole('list', { name: 'method' });
+        expect(methodDropdown).not.toBeInTheDocument();
+
+        const methodInput = screen.getByLabelText('결제수단');
+        fireEvent.click(methodInput);
+
+        const visibleMethodDropdown = screen.getByRole('list', { name: 'method' });
+        expect(visibleMethodDropdown).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/TransactionCreator/index.jsx
+++ b/frontend/src/components/TransactionCreator/index.jsx
@@ -1,18 +1,31 @@
 import React from 'react';
 
+import { useModal } from '../../hooks/useModal';
 import fabImg from '../../../public/assets/fab-button.svg';
 import { CreatorContainer, Creator, Fab } from './style';
 
+const initData = {
+    category: '',
+    color: '',
+    content: '',
+    method: '',
+    sign: '+',
+    cost: '',
+    date: '',
+};
+
 const TransactionCreator = () => {
+    const { openModal } = useModal();
+
     return (
         <>
             <CreatorContainer>
-                <Creator type="button" onClick={() => console.log(111)}>
+                <Creator type="button" onClick={() => openModal('createTransaction', initData)}>
                     내역 추가하기
                 </Creator>
             </CreatorContainer>
             <Fab>
-                <button type="button" onClick={() => console.log(111)}>
+                <button type="button" onClick={() => openModal('createTransaction', initData)}>
                     <img src={fabImg} />
                 </button>
             </Fab>

--- a/frontend/src/components/TransactionCreator/index.jsx
+++ b/frontend/src/components/TransactionCreator/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import fabImg from '../../../public/assets/fab-button.svg';
+import { CreatorContainer, Creator, Fab } from './style';
+
+const TransactionCreator = () => {
+    return (
+        <>
+            <CreatorContainer>
+                <Creator type="button" onClick={() => console.log(111)}>
+                    내역 추가하기
+                </Creator>
+            </CreatorContainer>
+            <Fab>
+                <button type="button" onClick={() => console.log(111)}>
+                    <img src={fabImg} />
+                </button>
+            </Fab>
+        </>
+    );
+};
+
+export default TransactionCreator;

--- a/frontend/src/components/TransactionCreator/style.js
+++ b/frontend/src/components/TransactionCreator/style.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
+
+export const CreatorContainer = styled.div`
+    margin: 20px auto 0px;
+    width: 90%;
+    height: 37px;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        display: none;
+    }
+`;
+
+export const Creator = styled.button`
+    width: 120px;
+    height: 100%;
+
+    font-weight: bold;
+    font-size: ${({ theme }) => theme.fontSize.default};
+    border: 2px solid ${({ theme }) => theme.color.mint};
+    color: ${({ theme }) => theme.color.white};
+    background-color: ${({ theme }) => theme.color.mint};
+`;
+
+export const Fab = styled.div`
+    display: none;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        z-index: 1;
+        position: fixed;
+        right: 5%;
+        bottom: 30px;
+
+        display: block;
+    }
+`;

--- a/frontend/src/components/TransactionModal/index.jsx
+++ b/frontend/src/components/TransactionModal/index.jsx
@@ -1,35 +1,48 @@
 import React from 'react';
 
 import TransactionUpdateForm from '../TransactionUpdateForm';
+import TransactionCreateForm from '../TransactionCreateForm';
 import CategoryForm from '../CategoryCreateForm';
 import { useModal } from '../../hooks/useModal';
-import { useCategory, useTransactionHandler } from './hooks';
+import { useCategory, useUpdateTransactionHandler, useCreateTransactionHandler } from './hooks';
 import { Wrapper, BackgroundDim } from './style';
 
 const TransactionModal = () => {
     const { isOpen, closeModal, getOpenModalByName } = useModal();
     const { addCategory } = useCategory(closeModal);
-    const { changeTransaction, removeTransaction } = useTransactionHandler();
+    const { changeTransaction, removeTransaction } = useUpdateTransactionHandler(closeModal);
+    const { addTransaction } = useCreateTransactionHandler(closeModal);
 
-    const transactionModal = getOpenModalByName('transaction');
+    const transactionUpdateModal = getOpenModalByName('updateTransaction');
+    const transactionCreateModal = getOpenModalByName('createTransaction');
     const categoryModal = getOpenModalByName('createCategory');
-    if (transactionModal == null) return null;
 
     return (
-        <Wrapper active={transactionModal != null} data-testid="modal">
+        <Wrapper active={transactionUpdateModal || transactionCreateModal} data-testid="modal">
             <BackgroundDim data-testid="dim" />
-            <TransactionUpdateForm
-                transaction={transactionModal.props}
-                onUpdate={changeTransaction}
-                onDelete={removeTransaction}
-                onCancle={() => closeModal('transaction')}
-            />
-            <CategoryForm
-                active={isOpen('createCategory')}
-                category={categoryModal?.props}
-                onCreate={addCategory}
-                onCancle={() => closeModal('createCategory')}
-            />
+            {transactionUpdateModal && (
+                <TransactionUpdateForm
+                    transaction={transactionUpdateModal.props}
+                    onUpdate={changeTransaction}
+                    onDelete={removeTransaction}
+                    onCancle={() => closeModal('updateTransaction')}
+                />
+            )}
+            {transactionCreateModal && (
+                <TransactionCreateForm
+                    transaction={transactionCreateModal.props}
+                    onCreate={addTransaction}
+                    onCancle={() => closeModal('createTransaction')}
+                />
+            )}
+            {categoryModal && (
+                <CategoryForm
+                    active={isOpen('createCategory')}
+                    category={categoryModal.props}
+                    onCreate={addCategory}
+                    onCancle={() => closeModal('createCategory')}
+                />
+            )}
         </Wrapper>
     );
 };

--- a/frontend/src/components/TransactionModal/test.js
+++ b/frontend/src/components/TransactionModal/test.js
@@ -22,13 +22,13 @@ describe('TransactionModal 컴포넌트 테스트', () => {
     const initializeState = ({ set }) => {
         set(modalState, [
             {
-                name: 'transaction',
+                name: 'updateTransaction',
                 props: TEST_DATA,
             },
         ]);
     };
 
-    it('배경 Dim, 입력 폼이 표시된다.', () => {
+    it('배경 Dim과 모달 Form이 표시된다.', () => {
         render(
             <RecoilRoot initializeState={initializeState}>
                 <ThemeProvider theme={theme}>
@@ -46,6 +46,6 @@ describe('TransactionModal 컴포넌트 테스트', () => {
     it('현재 선택된 modal의 props 속성이 없으면 모달이 표시되지 않는다.', () => {
         render(<TransactionModal />);
         const modalDiv = screen.queryByTestId('modal');
-        expect(modalDiv).not.toBeInTheDocument();
+        expect(modalDiv).not.toBeVisible();
     });
 });

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -75,7 +75,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                 <Input
                     type="text"
                     id="category"
-                    placeholder="입력하세요."
+                    placeholder="선택하세요."
                     autoComplete="off"
                     readOnly
                     value={inputs.category}
@@ -106,7 +106,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                 <Input
                     type="text"
                     id="method"
-                    placeholder="입력하세요."
+                    placeholder="선택하세요."
                     autoComplete="off"
                     readOnly
                     value={inputs.method}

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -32,7 +32,6 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         changeCost,
         removeCategory,
         openCategoryCreateModal,
-        addCategory,
     ] = useUpdateForm(transaction, onUpdate);
 
     return (

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -3,9 +3,9 @@ import React, { Suspense, useEffect } from 'react';
 import { usefetchMethodAndCategory } from './hooks';
 import Header from '../../components/Header';
 import Summary from '../../components/Summary';
+import TransactionCreator from '../../components/TransactionCreator';
 import Transactions from '../../components/Transactions';
-import fabImg from '../../../public/assets/fab-button.svg';
-import { MainWrapper, TransactionBox, CreatorContainer, Creator, Fab } from './style';
+import { MainWrapper, TransactionBox } from './style';
 
 const Main = () => {
     const [fetchMethod, fetchCategory] = usefetchMethodAndCategory();
@@ -23,16 +23,7 @@ const Main = () => {
                     <Summary />
                 </Suspense>
                 <TransactionBox>
-                    <CreatorContainer>
-                        <Creator type="button" onClick={() => console.log(111)}>
-                            내역 추가하기
-                        </Creator>
-                    </CreatorContainer>
-                    <Fab>
-                        <button type="button" onClick={() => console.log(111)}>
-                            <img src={fabImg} />
-                        </button>
-                    </Fab>
+                    <TransactionCreator />
                     <Suspense fallback={<div>Loading...</div>}>
                         <Transactions />
                     </Suspense>

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -28,16 +28,16 @@ const Main = () => {
                             내역 추가하기
                         </Creator>
                     </CreatorContainer>
+                    <Fab>
+                        <button type="button" onClick={() => console.log(111)}>
+                            <img src={fabImg} />
+                        </button>
+                    </Fab>
                     <Suspense fallback={<div>Loading...</div>}>
                         <Transactions />
                     </Suspense>
                 </TransactionBox>
             </MainWrapper>
-            <Fab>
-                <button type="button" onClick={() => console.log(111)}>
-                    <img src={fabImg} />
-                </button>
-            </Fab>
         </>
     );
 };

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -4,7 +4,8 @@ import { usefetchMethodAndCategory } from './hooks';
 import Header from '../../components/Header';
 import Summary from '../../components/Summary';
 import Transactions from '../../components/Transactions';
-import { MainWrapper } from './style';
+import fabImg from '../../../public/assets/fab-button.svg';
+import { MainWrapper, TransactionBox, CreatorContainer, Creator, Fab } from './style';
 
 const Main = () => {
     const [fetchMethod, fetchCategory] = usefetchMethodAndCategory();
@@ -21,10 +22,22 @@ const Main = () => {
                 <Suspense fallback={<div>Loading...</div>}>
                     <Summary />
                 </Suspense>
-                <Suspense fallback={<div>Loading...</div>}>
-                    <Transactions />
-                </Suspense>
+                <TransactionBox>
+                    <CreatorContainer>
+                        <Creator type="button" onClick={() => console.log(111)}>
+                            내역 추가하기
+                        </Creator>
+                    </CreatorContainer>
+                    <Suspense fallback={<div>Loading...</div>}>
+                        <Transactions />
+                    </Suspense>
+                </TransactionBox>
             </MainWrapper>
+            <Fab>
+                <button type="button" onClick={() => console.log(111)}>
+                    <img src={fabImg} />
+                </button>
+            </Fab>
         </>
     );
 };

--- a/frontend/src/pages/Main/style.js
+++ b/frontend/src/pages/Main/style.js
@@ -26,37 +26,3 @@ export const TransactionBox = styled.div`
     width: 100%;
     height: calc(100% - 150px);
 `;
-
-export const CreatorContainer = styled.div`
-    margin: 20px auto 0px;
-    width: 90%;
-    height: 37px;
-
-    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        display: none;
-    }
-`;
-
-export const Creator = styled.button`
-    width: 120px;
-    height: 100%;
-
-    font-weight: bold;
-    font-size: ${({ theme }) => theme.fontSize.default};
-    border: 2px solid ${({ theme }) => theme.color.mint};
-    color: ${({ theme }) => theme.color.white};
-    background-color: ${({ theme }) => theme.color.mint};
-`;
-
-export const Fab = styled.div`
-    display: none;
-
-    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        z-index: 1;
-        position: fixed;
-        right: 5%;
-        bottom: 30px;
-
-        display: block;
-    }
-`;

--- a/frontend/src/pages/Main/style.js
+++ b/frontend/src/pages/Main/style.js
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
 
 export const MainWrapper = styled.div`
-    width: calc(100vw - 15px);
+    width: 100vw;
     height: calc(100vh - 125px);
     min-width: 228px;
 
     display: flex;
     flex-direction: row;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: flex-start;
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
@@ -19,5 +19,44 @@ export const MainWrapper = styled.div`
         flex-direction: column;
         justify-content: flex-start;
         align-items: center;
+    }
+`;
+
+export const TransactionBox = styled.div`
+    width: 100%;
+    height: calc(100% - 150px);
+`;
+
+export const CreatorContainer = styled.div`
+    margin: 20px auto 0px;
+    width: 90%;
+    height: 37px;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        display: none;
+    }
+`;
+
+export const Creator = styled.button`
+    width: 120px;
+    height: 100%;
+
+    font-weight: bold;
+    font-size: ${({ theme }) => theme.fontSize.default};
+    border: 2px solid ${({ theme }) => theme.color.mint};
+    color: ${({ theme }) => theme.color.white};
+    background-color: ${({ theme }) => theme.color.mint};
+`;
+
+export const Fab = styled.div`
+    display: none;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        z-index: 1;
+        position: fixed;
+        right: 5%;
+        bottom: 30px;
+
+        display: block;
     }
 `;


### PR DESCRIPTION
### PC 버전
![image](https://user-images.githubusercontent.com/67899069/153405632-cb4ca1d7-fb38-4ba8-8239-effab2f1da7d.png)
![image](https://user-images.githubusercontent.com/67899069/153405916-4849b5bf-1f51-4446-a2e4-3c4d3de893bc.png)


### 모바일 버전(iPhone SE)
![image](https://user-images.githubusercontent.com/67899069/153406054-0b38c58d-ae75-406b-8644-884984331c6f.png)![image](https://user-images.githubusercontent.com/67899069/153406015-d4973ee9-336e-494c-aea8-a44932871998.png)

## 구현한 내용
* 거래내역을 추가하기 위한 버튼을 구현했습니다.
    * PC의 경우 거래내역 상단에 추가 버튼이 위치합니다.
    * 모바일의 경우 우측 하단에 추가 버튼이 위치합니다.

## 추가상식
1. display: none과 같이 화면에 보이지 않는 요소 테스트
* 처음에는 display: none의 경우 not.toBeInTheDocument( )와 같은 요소로 테스트를 시도했습니다.
* 하지만 이 경우에도 기하학적인 위치조정과 Paint 과정이 없었을 뿐 트리에는 존재했기 때문에, not.toBeVisible( )과 같이 눈에 보이지 않는다는 의미로 테스트를 진행했습니다.

## 체크리스트
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지