### PR TITLE
[Sprint 1] 프론트엔드 UI 로직 강화(카테고리 분기, 입력값 검증 및 반응형 FIX)

### DIFF
--- a/frontend/src/components/Dropdown/style.js
+++ b/frontend/src/components/Dropdown/style.js
@@ -17,7 +17,7 @@ export const Wrapper = styled.ul`
     box-shadow: ${({ theme }) => theme.shadow.pale};
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
-        margin-top: ${(props) => (props.name === 'category' ? '47.2vh' : '73.3vh')};
+        margin-top: ${(props) => (props['aria-label'] === 'category' ? '47.2vh' : '73.3vh')};
         width: 80vw;
         top: 0;
     }

--- a/frontend/src/components/TransactionCreateForm/hooks.js
+++ b/frontend/src/components/TransactionCreateForm/hooks.js
@@ -16,6 +16,10 @@ export const useCreateForm = (transaction, onCreate) => {
 
     const { openModal } = useModal();
 
+    const categoriesInCostType = () => {
+        return categories.filter((category) => category.sign === inputs.sign);
+    };
+
     const handleCreateSubmit = (e) => {
         e.preventDefault();
         onCreate(inputs);
@@ -70,7 +74,7 @@ export const useCreateForm = (transaction, onCreate) => {
         activeMethod,
         inputs,
         methods,
-        categories,
+        categoriesInCostType,
         handleCreateSubmit,
         categoryActiveToggle,
         methodActiveToggle,

--- a/frontend/src/components/TransactionCreateForm/hooks.js
+++ b/frontend/src/components/TransactionCreateForm/hooks.js
@@ -5,6 +5,14 @@ import { useModal } from '../../hooks/useModal';
 import { methodState } from '../../recoil/method/atom';
 import { categoryState } from '../../recoil/category/atom';
 import { deleteCategory } from '../../lib/category';
+import {
+    dateFormat,
+    CategoryFormat,
+    ContentFormat,
+    MethodFormat,
+    CostFormat,
+    formatValidator,
+} from '../../utils/common/input-validator';
 
 export const useCreateForm = (transaction, onCreate) => {
     const [activeCategory, setActiveCategory] = useState(false);
@@ -22,7 +30,23 @@ export const useCreateForm = (transaction, onCreate) => {
 
     const handleCreateSubmit = (e) => {
         e.preventDefault();
-        onCreate(inputs);
+
+        const validateFormats = [
+            CategoryFormat,
+            ContentFormat,
+            MethodFormat,
+            CostFormat,
+            dateFormat,
+        ];
+
+        const { color, sign, ...targets } = inputs;
+        let inValidCount = 0;
+        Object.values(targets).forEach((target, index) => {
+            const result = formatValidator(validateFormats[index], target);
+            if (result !== '유효한 결과 값입니다.') inValidCount += 1;
+        });
+        // TODO null에 토스트창 띄우기
+        inValidCount === 0 ? onCreate(inputs) : null;
     };
 
     const categoryActiveToggle = () => {

--- a/frontend/src/components/TransactionCreateForm/hooks.js
+++ b/frontend/src/components/TransactionCreateForm/hooks.js
@@ -13,6 +13,7 @@ import {
     CostFormat,
     formatValidator,
 } from '../../utils/common/input-validator';
+import { VALID_INPUT } from '../../utils/constant/valid-message';
 
 export const useCreateForm = (transaction, onCreate) => {
     const [activeCategory, setActiveCategory] = useState(false);
@@ -43,7 +44,7 @@ export const useCreateForm = (transaction, onCreate) => {
         let inValidCount = 0;
         Object.values(targets).forEach((target, index) => {
             const result = formatValidator(validateFormats[index], target);
-            if (result !== '유효한 결과 값입니다.') inValidCount += 1;
+            if (result !== VALID_INPUT) inValidCount += 1;
         });
         // TODO null에 토스트창 띄우기
         inValidCount === 0 ? onCreate(inputs) : null;

--- a/frontend/src/components/TransactionCreateForm/index.jsx
+++ b/frontend/src/components/TransactionCreateForm/index.jsx
@@ -20,7 +20,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
         activeMethod,
         inputs,
         methods,
-        categories,
+        categoriesInCostType,
         handleCreateSubmit,
         categoryActiveToggle,
         methodActiveToggle,
@@ -83,7 +83,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
                 />
                 <Dropdown
                     name="category"
-                    data={categories}
+                    data={categoriesInCostType()}
                     active={activeCategory}
                     changeHandler={changeCategory}
                     deleteHandler={removeCategory}

--- a/frontend/src/components/TransactionCreateForm/test.js
+++ b/frontend/src/components/TransactionCreateForm/test.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { RecoilRoot } from 'recoil';
 import { render, screen, fireEvent } from '../../test-utils';
 
 import TransactionCreateForm from '.';
+import { categoryState } from '../../recoil/category/atom';
 
 const TEST_DATA = {
     category: '',
@@ -12,7 +14,21 @@ const TEST_DATA = {
     sign: '+',
 };
 
+const TEST_CATEGORY_DATA = [
+    { id: 1, name: '미분류', color: '#817DCE', sign: 'all' },
+    { id: 2, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { id: 4, name: '용돈', color: '#E6D267', sign: '+' },
+    { id: 5, name: '교통', color: '#94D3CC', sign: '-' },
+    { id: 10, name: '월급', color: '#B9D58C', sign: '+' },
+    { id: 13, name: '식비', color: '#4CA1DE', sign: '-' },
+    { id: 14, name: '여행/숙박', color: '#E2B765', sign: '-' },
+];
+
 describe('TransactionCreateForm 테스트', () => {
+    const initializeState = ({ set }) => {
+        set(categoryState, TEST_CATEGORY_DATA);
+    };
+
     it('기본 요소들이 표시된다.', () => {
         render(<TransactionCreateForm transaction={TEST_DATA} onCreate={null} onCancle={null} />);
 
@@ -81,5 +97,41 @@ describe('TransactionCreateForm 테스트', () => {
 
         const visibleMethodDropdown = screen.getByRole('list', { name: 'method' });
         expect(visibleMethodDropdown).toBeInTheDocument();
+    });
+
+    it('수입 버튼에 클릭되어 있는 경우, 카테고리 input을 누르면 수입에 해당하는 카테고리들이 표시된다.', () => {
+        render(
+            <RecoilRoot initializeState={initializeState}>
+                <TransactionCreateForm transaction={TEST_DATA} onCreate={null} onCancle={null} />
+            </RecoilRoot>,
+        );
+
+        const categoryInput = screen.getByLabelText('카테고리');
+        fireEvent.click(categoryInput);
+
+        const datas = ['용돈', '월급'];
+        datas.forEach((data) => {
+            expect(screen.getByText(data)).toBeInTheDocument();
+        });
+    });
+
+    it('지출 버튼에 클릭되어 있는 경우, 카테고리 input을 누르면 지출에 해당하는 카테고리들이 표시된다.', () => {
+        render(
+            <RecoilRoot initializeState={initializeState}>
+                <TransactionCreateForm
+                    transaction={{ ...TEST_DATA, sign: '-' }}
+                    onCreate={null}
+                    onCancle={null}
+                />
+            </RecoilRoot>,
+        );
+
+        const categoryInput = screen.getByLabelText('카테고리');
+        fireEvent.click(categoryInput);
+
+        const datas = ['카페/간식', '교통', '식비', '여행/숙박'];
+        datas.forEach((data) => {
+            expect(screen.getByText(data)).toBeInTheDocument();
+        });
     });
 });

--- a/frontend/src/components/TransactionUpdateForm/hooks.js
+++ b/frontend/src/components/TransactionUpdateForm/hooks.js
@@ -13,6 +13,7 @@ import {
     CostFormat,
     formatValidator,
 } from '../../utils/common/input-validator';
+import { VALID_INPUT } from '../../utils/constant/valid-message';
 
 export const useUpdateForm = (transaction, onUpdate) => {
     const [activeCategory, setActiveCategory] = useState(false);
@@ -43,7 +44,7 @@ export const useUpdateForm = (transaction, onUpdate) => {
         let inValidCount = 0;
         Object.values(targets).forEach((target, index) => {
             const result = formatValidator(validateFormats[index], target);
-            if (result !== '유효한 결과 값입니다.') inValidCount += 1;
+            if (result !== VALID_INPUT) inValidCount += 1;
         });
         // TODO null에 토스트창 띄우기
         inValidCount === 0 ? onUpdate(inputs) : null;

--- a/frontend/src/components/TransactionUpdateForm/hooks.js
+++ b/frontend/src/components/TransactionUpdateForm/hooks.js
@@ -16,6 +16,10 @@ export const useUpdateForm = (transaction, onUpdate) => {
 
     const { openModal } = useModal();
 
+    const categoriesInCostType = () => {
+        return categories.filter((category) => category.sign === inputs.sign);
+    };
+
     const handleUpdateSubmit = (e) => {
         e.preventDefault();
         onUpdate(inputs);
@@ -70,7 +74,7 @@ export const useUpdateForm = (transaction, onUpdate) => {
         activeMethod,
         inputs,
         methods,
-        categories,
+        categoriesInCostType,
         handleUpdateSubmit,
         categoryActiveToggle,
         methodActiveToggle,

--- a/frontend/src/components/TransactionUpdateForm/hooks.js
+++ b/frontend/src/components/TransactionUpdateForm/hooks.js
@@ -5,6 +5,14 @@ import { useModal } from '../../hooks/useModal';
 import { methodState } from '../../recoil/method/atom';
 import { categoryState } from '../../recoil/category/atom';
 import { deleteCategory } from '../../lib/category';
+import {
+    dateFormat,
+    CategoryFormat,
+    ContentFormat,
+    MethodFormat,
+    CostFormat,
+    formatValidator,
+} from '../../utils/common/input-validator';
 
 export const useUpdateForm = (transaction, onUpdate) => {
     const [activeCategory, setActiveCategory] = useState(false);
@@ -22,7 +30,23 @@ export const useUpdateForm = (transaction, onUpdate) => {
 
     const handleUpdateSubmit = (e) => {
         e.preventDefault();
-        onUpdate(inputs);
+
+        const validateFormats = [
+            CategoryFormat,
+            ContentFormat,
+            MethodFormat,
+            CostFormat,
+            dateFormat,
+        ];
+
+        const { id, color, sign, ...targets } = inputs;
+        let inValidCount = 0;
+        Object.values(targets).forEach((target, index) => {
+            const result = formatValidator(validateFormats[index], target);
+            if (result !== '유효한 결과 값입니다.') inValidCount += 1;
+        });
+        // TODO null에 토스트창 띄우기
+        inValidCount === 0 ? onUpdate(inputs) : null;
     };
 
     const categoryActiveToggle = () => {

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -20,7 +20,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         activeMethod,
         inputs,
         methods,
-        categories,
+        categoriesInCostType,
         handleUpdateSubmit,
         categoryActiveToggle,
         methodActiveToggle,
@@ -83,7 +83,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                 />
                 <Dropdown
                     name="category"
-                    data={categories}
+                    data={categoriesInCostType()}
                     active={activeCategory}
                     changeHandler={changeCategory}
                     deleteHandler={removeCategory}

--- a/frontend/src/components/TransactionUpdateForm/test.js
+++ b/frontend/src/components/TransactionUpdateForm/test.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { RecoilRoot } from 'recoil';
 import { render, screen, fireEvent } from '../../test-utils';
 
 import TransactionUpdateForm from '.';
+import { categoryState } from '../../recoil/category/atom';
 
 const TEST_DATA = {
     category: '카페/간식',
@@ -12,7 +14,21 @@ const TEST_DATA = {
     sign: '-',
 };
 
+const TEST_CATEGORY_DATA = [
+    { id: 1, name: '미분류', color: '#817DCE', sign: 'all' },
+    { id: 2, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { id: 4, name: '용돈', color: '#E6D267', sign: '+' },
+    { id: 5, name: '교통', color: '#94D3CC', sign: '-' },
+    { id: 10, name: '월급', color: '#B9D58C', sign: '+' },
+    { id: 13, name: '식비', color: '#4CA1DE', sign: '-' },
+    { id: 14, name: '여행/숙박', color: '#E2B765', sign: '-' },
+];
+
 describe('TransactionUpateForm 테스트', () => {
+    const initializeState = ({ set }) => {
+        set(categoryState, TEST_CATEGORY_DATA);
+    };
+
     it('기본 요소들이 표시된다.', () => {
         render(
             <TransactionUpdateForm
@@ -130,5 +146,47 @@ describe('TransactionUpateForm 테스트', () => {
 
         const visibleMethodDropdown = screen.getByRole('list', { name: 'method' });
         expect(visibleMethodDropdown).toBeInTheDocument();
+    });
+
+    it('수입 버튼에 클릭되어 있는 경우, 카테고리 input을 누르면 수입에 해당하는 카테고리들이 표시된다.', () => {
+        render(
+            <RecoilRoot initializeState={initializeState}>
+                <TransactionUpdateForm
+                    transaction={{ ...TEST_DATA, sign: '+' }}
+                    onUpdate={null}
+                    onDelete={null}
+                    onCancle={null}
+                />
+            </RecoilRoot>,
+        );
+
+        const categoryInput = screen.getByLabelText('카테고리');
+        fireEvent.click(categoryInput);
+
+        const datas = ['용돈', '월급'];
+        datas.forEach((data) => {
+            expect(screen.getByText(data)).toBeInTheDocument();
+        });
+    });
+
+    it('지출 버튼에 클릭되어 있는 경우, 카테고리 input을 누르면 지출에 해당하는 카테고리들이 표시된다.', () => {
+        render(
+            <RecoilRoot initializeState={initializeState}>
+                <TransactionUpdateForm
+                    transaction={TEST_DATA}
+                    onUpdate={null}
+                    onDelete={null}
+                    onCancle={null}
+                />
+            </RecoilRoot>,
+        );
+
+        const categoryInput = screen.getByLabelText('카테고리');
+        fireEvent.click(categoryInput);
+
+        const datas = ['카페/간식', '교통', '식비', '여행/숙박'];
+        datas.forEach((data) => {
+            expect(screen.getByText(data)).toBeInTheDocument();
+        });
     });
 });

--- a/frontend/src/utils/common/input-validator/index.js
+++ b/frontend/src/utils/common/input-validator/index.js
@@ -1,0 +1,34 @@
+export const dateFormat = {
+    rule: /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/,
+    match: true,
+    message: '날짜는 YYYY-MM-DD 형식으로 입력해야 합니다.',
+};
+
+export const CategoryFormat = {
+    rule: /.+/,
+    match: true,
+    message: '카테고리를 선택해야 합니다.',
+};
+
+export const ContentFormat = {
+    rule: /.+/,
+    match: true,
+    message: '내용은 최소 한 글자 이상 입력해야 합니다.',
+};
+
+export const MethodFormat = {
+    rule: /.+/,
+    match: true,
+    message: '결제수단을 선택해야 합니다.',
+};
+
+export const CostFormat = {
+    rule: /^[0-9]{1,}$/,
+    match: true,
+    message: '한자리 이상의 숫자만 입력해야 합니다.(콤마는 입력하지 않습니다.)',
+};
+
+export const formatValidator = (format, target) => {
+    const isValid = format.rule.test(target) === format.match;
+    return isValid ? '유효한 결과 값입니다.' : format.message;
+};

--- a/frontend/src/utils/common/input-validator/index.js
+++ b/frontend/src/utils/common/input-validator/index.js
@@ -1,34 +1,43 @@
+import {
+    VALID_INPUT,
+    INVALID_DATE,
+    INVALID_CATEGORY,
+    INVALID_CONTENT,
+    INVALID_METHOD,
+    INVALID_COST,
+} from '../../constant/valid-message';
+
 export const dateFormat = {
     rule: /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/,
     match: true,
-    message: '날짜는 YYYY-MM-DD 형식으로 입력해야 합니다.',
+    message: INVALID_DATE,
 };
 
 export const CategoryFormat = {
     rule: /.+/,
     match: true,
-    message: '카테고리를 선택해야 합니다.',
+    message: INVALID_CATEGORY,
 };
 
 export const ContentFormat = {
     rule: /.+/,
     match: true,
-    message: '내용은 최소 한 글자 이상 입력해야 합니다.',
+    message: INVALID_CONTENT,
 };
 
 export const MethodFormat = {
     rule: /.+/,
     match: true,
-    message: '결제수단을 선택해야 합니다.',
+    message: INVALID_METHOD,
 };
 
 export const CostFormat = {
     rule: /^[0-9]{1,}$/,
     match: true,
-    message: '한자리 이상의 숫자만 입력해야 합니다.(콤마는 입력하지 않습니다.)',
+    message: INVALID_COST,
 };
 
 export const formatValidator = (format, target) => {
     const isValid = format.rule.test(target) === format.match;
-    return isValid ? '유효한 결과 값입니다.' : format.message;
+    return isValid ? VALID_INPUT : format.message;
 };

--- a/frontend/src/utils/constant/valid-message.js
+++ b/frontend/src/utils/constant/valid-message.js
@@ -1,0 +1,6 @@
+export const VALID_INPUT = '유효한 결과 값입니다.';
+export const INVALID_DATE = '날짜는 YYYY-MM-DD 형식으로 입력해야 합니다.';
+export const INVALID_CATEGORY = '카테고리를 선택해야 합니다.';
+export const INVALID_CONTENT = '내용은 최소 한 글자 이상 입력해야 합니다.';
+export const INVALID_METHOD = '결제수단을 선택해야 합니다.';
+export const INVALID_COST = '한자리 이상의 숫자만 입력해야 합니다.(콤마는 입력하지 않습니다.)';


### PR DESCRIPTION
## 구현한 내용
* 드롭다운에 name 속성을 aria-label로 변경함에 따른 반응형 style 분기로직 오류를 수정했습니다.
* 수입, 지출에 따라 카테고리 리스트가 필터링되어 렌더링 되도록 구현했습니다.
* 거래내역 생성, 수정 폼의 입력값에 대한 검증로직을 추가했습니다.

## 체크리스트
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지