### PR TITLE
[Sprint 1] 카테고리 중 (카페/간식, 식비 등) 일부 카테고리는 공통 카테고리로 제공하도록 변경

### DIFF
--- a/backend/service/category-service.js
+++ b/backend/service/category-service.js
@@ -2,12 +2,13 @@ import pool from '../database/connection.js';
 import UserService from './user-service.js';
 
 const getCategories = async (nickname) => {
+    const COMMON_UID = 0;
     const [userId] = await UserService.getUserId(nickname);
     const sql = `
         SELECT id, name, color, sign 
         FROM category 
-        WHERE uid = ?`;
-    const [row] = await pool.query(sql, [userId.id]);
+        WHERE uid IN (?, ?)`;
+    const [row] = await pool.query(sql, [COMMON_UID, userId.id]);
     return row;
 };
 


### PR DESCRIPTION
 ## 구현한 내용
* 유저별로 카테고리를 모두 분리하도록 설계되어 있었습니다.
* 하지만 카페/간식, 식비와 같은 기본요소들은 특정 유저에게 종속적인 것이 아니라 모든 유저에게 default로 제공할 필요가 있다고 판단해서 수정하게 되었습니다.
* default로 모든 유저에게 기본 제공되는 카테고리는 column값이 0으로 설정됩니다.

## 체크리스트
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지