### PR TITLE
[Sprint 1] 드롭다운 이외의 영역 클릭 시 닫히도록 dim 구현

### DIFF
--- a/frontend/src/components/Dropdown/index.jsx
+++ b/frontend/src/components/Dropdown/index.jsx
@@ -2,9 +2,21 @@ import React from 'react';
 import { nanoid } from 'nanoid';
 
 import deleteImg from '../../../public/assets/delete-button.svg';
-import { Wrapper, Item } from './style';
+import { BackgroundDim, Wrapper, Items, Item } from './style';
 
-const Dropdown = ({ name, data, active, changeHandler, deleteHandler, createHandler }) => {
+const Dropdown = ({
+    name,
+    data,
+    active,
+    activeToggle,
+    changeHandler,
+    deleteHandler,
+    createHandler,
+}) => {
+    const dimHandler = () => {
+        activeToggle();
+    };
+
     const items = data.map((_data) => (
         <Item key={nanoid()} onClick={changeHandler}>
             <span>{_data.name}</span>
@@ -15,14 +27,19 @@ const Dropdown = ({ name, data, active, changeHandler, deleteHandler, createHand
     ));
 
     return (
-        <Wrapper active={active} aria-label={name}>
-            {items}
-            {createHandler && (
-                <Item>
-                    <button type="button" aria-label="addCategory" onClick={createHandler}>
-                        추가하기
-                    </button>
-                </Item>
+        <Wrapper active={active}>
+            <BackgroundDim data-testid="dropdown-dim" onClick={dimHandler} />
+            {active && (
+                <Items aria-label={name}>
+                    {items}
+                    {createHandler && (
+                        <Item>
+                            <button type="button" aria-label="addCategory" onClick={createHandler}>
+                                추가하기
+                            </button>
+                        </Item>
+                    )}
+                </Items>
             )}
         </Wrapper>
     );

--- a/frontend/src/components/Dropdown/style.js
+++ b/frontend/src/components/Dropdown/style.js
@@ -2,15 +2,27 @@ import styled from 'styled-components';
 
 import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
 
-export const Wrapper = styled.ul`
+export const Wrapper = styled.div`
+    visibility: ${(props) => (props.active ? 'visible' : 'hidden')};
+`;
+
+export const BackgroundDim = styled.div`
+    position: fixed;
     z-index: 3;
+
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+`;
+
+export const Items = styled.ul`
+    z-index: 4;
     margin-top: 60px;
     position: absolute;
     width: 250px;
     max-height: 120px;
     overflow-y: scroll;
-
-    visibility: ${(props) => (props.active ? 'visible' : 'hidden')};
 
     border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
     background-color: ${({ theme }) => theme.color.white};

--- a/frontend/src/components/Dropdown/test.js
+++ b/frontend/src/components/Dropdown/test.js
@@ -12,11 +12,13 @@ const TEST_DATA = [
 ];
 
 describe('TransactionUpateForm 테스트', () => {
-    it('item 들을 정상적으로 표시한다.', () => {
+    it('배경 dim과 item 들을 정상적으로 표시한다.', () => {
         render(<Dropdown data={TEST_DATA} active={true} />);
 
+        const BackgroundDim = screen.getByTestId('dropdown-dim');
         const items = screen.getAllByRole('listitem');
 
+        expect(BackgroundDim).toBeInTheDocument();
         expect(items).toHaveLength(TEST_DATA.length);
         items.forEach((item, index) => {
             expect(item).toHaveTextContent(TEST_DATA[index].name);

--- a/frontend/src/components/TransactionCreateForm/index.jsx
+++ b/frontend/src/components/TransactionCreateForm/index.jsx
@@ -86,6 +86,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
                     name="category"
                     data={categoriesInCostType()}
                     active={activeCategory}
+                    activeToggle={categoryActiveToggle}
                     changeHandler={changeCategory}
                     deleteHandler={removeCategory}
                     createHandler={openCategoryCreateModal}
@@ -117,6 +118,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
                     name="method"
                     data={methods}
                     active={activeMethod}
+                    activeToggle={methodActiveToggle}
                     changeHandler={changeMethod}
                 />
             </Element>

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -86,6 +86,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     name="category"
                     data={categoriesInCostType()}
                     active={activeCategory}
+                    activeToggle={categoryActiveToggle}
                     changeHandler={changeCategory}
                     deleteHandler={removeCategory}
                     createHandler={openCategoryCreateModal}
@@ -117,6 +118,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     name="method"
                     data={methods}
                     active={activeMethod}
+                    activeToggle={methodActiveToggle}
                     changeHandler={changeMethod}
                 />
             </Element>


### PR DESCRIPTION
 ## 구현한 내용
* 드롭다운이 display되는 경우 배경에 dim 역할을 수행하는 요소를 같이 렌더링 해줬습니다.
* 드롭다운 이외의 영역(dim 영역)을 클릭하는 경우 드롭다운이 닫히도록 구현했습니다.
* 드롭다운의 z-index는 4, 배경의 dim은 3입니다.
* 아래 이미지에서 가장 상단의 모달은 드롭다운을 의미합니다.
![image](https://user-images.githubusercontent.com/67899069/153590057-c598eb5d-fc7a-4e9a-9624-201da122eae8.png)

## 체크리스트
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지