### PR TITLE
[Sprint 2] 카테고리 비율에 대한 도넛 차트 구현 #16

### DIFF
--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -26,10 +26,13 @@ const Statistics = () => {
 
     const [cx, cy, r, width, startAngle] = [50, 50, 30, 15, -90];
     const dashArray = 2 * Math.PI * r;
+    const animationDuration = 1000;
     let accumulatePercent = 0;
     const circles = datas.map((data) => {
         const dashOffset = dashArray - (dashArray * data.percent) / 100;
         const angle = (accumulatePercent * 360) / 100 + startAngle;
+        const currentDuration = (animationDuration * data.percent) / 100;
+        const delay = (animationDuration * accumulatePercent) / 100;
         accumulatePercent += data.percent;
         return (
             <DonutCircle
@@ -43,6 +46,8 @@ const Statistics = () => {
                 dashArray={dashArray}
                 dashOffset={dashOffset}
                 angle={angle}
+                currentDuration={currentDuration}
+                delay={delay}
             />
         );
     });

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -1,7 +1,60 @@
-import React from 'react';
+import React, { Suspense } from 'react';
+import { nanoid } from 'nanoid';
+
+import Header from '../../components/Header';
+import { MainWrapper, DonutCircle } from './style';
 
 const Statistics = () => {
-    return <div>통계 페이지 입니다.</div>;
+    const datas = [
+        {
+            percent: 37,
+            color: '#80e080',
+        },
+        {
+            percent: 33,
+            color: '#4fc3f7',
+        },
+        {
+            percent: 20,
+            color: '#9575cd',
+        },
+        {
+            percent: 10,
+            color: '#f06292',
+        },
+    ];
+
+    const [cx, cy, r, width, startAngle] = [50, 50, 30, 15, -90];
+    const dashArray = 2 * Math.PI * r;
+    let accumulatePercent = 0;
+    const circles = datas.map((data) => {
+        const dashOffset = dashArray - (dashArray * data.percent) / 100;
+        const angle = (accumulatePercent * 360) / 100 + startAngle;
+        accumulatePercent += data.percent;
+        return (
+            <DonutCircle
+                key={nanoid()}
+                cx={cx}
+                cy={cy}
+                r={r}
+                fill={'transparent'}
+                color={data.color}
+                width={width}
+                dashArray={dashArray}
+                dashOffset={dashOffset}
+                angle={angle}
+            />
+        );
+    });
+
+    return (
+        <Suspense fallback={<div>Loading...</div>}>
+            <Header current={'statistics'} />
+            <MainWrapper>
+                <svg viewBox="0 0 100 100">{circles}</svg>
+            </MainWrapper>
+        </Suspense>
+    );
 };
 
 export default Statistics;

--- a/frontend/src/pages/Statistics/style.js
+++ b/frontend/src/pages/Statistics/style.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export const MainWrapper = styled.div`
+    width: 100vw;
+    height: calc(100vh - 125px);
+    min-width: 228px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+`;
+
+export const DonutCircle = styled.circle`
+    cx: ${(props) => props.cx};
+    cy: ${(props) => props.cy};
+    r: ${(props) => props.r};
+    fill: ${(props) => props.fill};
+
+    stroke: ${(props) => props.color};
+    stroke-width: ${(props) => props.width};
+    stroke-dasharray: ${(props) => props.dashArray};
+    stroke-dashoffset: ${(props) => props.dashOffset};
+    transform: rotate(${(props) => props.angle}deg);
+    transform-origin: ${(props) => props.cx}px ${(props) => props.cy}px;
+`;

--- a/frontend/src/pages/Statistics/style.js
+++ b/frontend/src/pages/Statistics/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 export const MainWrapper = styled.div`
     width: 100vw;
@@ -11,6 +11,12 @@ export const MainWrapper = styled.div`
     align-items: center;
 `;
 
+const draw = (dashOffset) => keyframes`
+    100% {
+            stroke-dashoffset: ${dashOffset};
+    }
+`;
+
 export const DonutCircle = styled.circle`
     cx: ${(props) => props.cx};
     cy: ${(props) => props.cy};
@@ -20,7 +26,10 @@ export const DonutCircle = styled.circle`
     stroke: ${(props) => props.color};
     stroke-width: ${(props) => props.width};
     stroke-dasharray: ${(props) => props.dashArray};
-    stroke-dashoffset: ${(props) => props.dashOffset};
+    stroke-dashoffset: ${(props) => props.dashArray};
     transform: rotate(${(props) => props.angle}deg);
     transform-origin: ${(props) => props.cx}px ${(props) => props.cy}px;
+
+    animation: ${(props) => draw(props.dashOffset)} ${(props) => props.currentDuration}ms
+        ${(props) => props.delay}ms linear forwards;
 `;


### PR DESCRIPTION
### PC 버전 
![image](https://user-images.githubusercontent.com/67899069/154139804-eb0de6dc-74ec-4a63-89cd-83ec391e8f0d.png)

### 모바일 버전(iPhone SE)
![image](https://user-images.githubusercontent.com/67899069/154139774-a815c41f-2bdd-4d95-8862-0c2b1c13e401.png)

## 구현한 내용
* 더미데이터 기반으로 도넛차트를 그리는 로직을 구현했습니다.
    * 반응형에서 이점을 가져가기 위해서 SVG의 viewbox를 활용했습니다.
    * 벡터 기반으로 해상도에 따라 크기가 유연하게 조절됩니다(SVG를 선택한 이유).
    * SVG 태그 내에 카테고리별 요소들을 Circle을 활용해서 그렸습니다.
 * 도넛 차트에 애니메이션을 적용했습니다.
    * animation과 keyframes를 활용했습니다.

## 어려웠던 점 및 해결한 방향
1. 도넛차트에 애니메이션 적용하기
* 카테고리 별로 애니메이션을 줄 때 순서대로 자연스럽게 이어서 그려지기 위해서는 카테고리 별로 delay가 필요했습니다.
* 가장 먼저 setTimeout과 같은 API를 생각해 볼 수 있었지만, CSS의 animation-delay 속성을 활용해서 원하는 애니메이션을 지연 시킬 수 있었습니다.
```
animation: [애니메이션 이름] [실행시간] [지연시간];
```
* 추가적으로 애니메이션 적용 시 초기에는 그려지지 않고 delay 시간이 지난 뒤에 해당 카테고리의 요소를 그려야 했기 때문에 초기의 stroke-dashoffset을 stroke-dasharray과 같은 값을 할당했습니다.
* 이 경우 animation이 동작했을 때만 그려지고 끝난 후에는 그려진 부분이 사라지고 초기의 값으로 다시 돌아가는 이슈가 있었습니다.
* 해당 부분에 대해서는 이벤트가 끝난 후의 결과를 유지하는 animation의 forwards 속성을 활용해서 해결할 수 있었습니다.

### 추가상식
1. styled-components에서 Circle요소 및 Keyframe 활용하기
* 중심점을 기준으로 시작점에 대한 조정을 하는 rotate로직을 styled-components에서 하는경우 아래와 같이 사용해야 합니다.
```
// 기존의 사용방식
transform="rotate(180 50 50)"

// styled-componets에서의 사용방식
transform: rotate(180deg);
transform-origin: 50px 50px;
```
* Keyframe의 경우 props를 전달해서 사용이 가능합니다.
```
const draw = (dashOffset) => keyframes`
  100% {
          stroke-dashoffset: ${dashOffset};
  }
`;
```


## 체크리스트
- [x]  PC, 모바일 버전에 맞춰서 반응형 웹 구현하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지