### PR TITLE
[Sprint 2] 카테고리 별 지출 비율 및 금액을 나타내는 컴포넌트 구현 #17

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { RecoilRoot } from 'recoil';
 import { ThemeProvider } from 'styled-components';
 
@@ -11,7 +11,9 @@ const App = () => {
         <RecoilRoot>
             <GlobalStyle />
             <ThemeProvider theme={theme}>
-                <Router />
+                <Suspense fallback={<div>Loading...</div>}>
+                    <Router />
+                </Suspense>
             </ThemeProvider>
         </RecoilRoot>
     );

--- a/frontend/src/components/CalendarTable/hooks.js
+++ b/frontend/src/components/CalendarTable/hooks.js
@@ -17,13 +17,3 @@ export const useWeek = () => {
 
     return { currentDate, baseDay, firstWeek, lastWeek };
 };
-
-export const useCost = () => {
-    const rawTransactions = useRecoilValue(transactionsInDateState);
-
-    const income = calculateIncome(rawTransactions);
-    const expenditure = calculateExpenditure(rawTransactions);
-    const total = income - expenditure;
-
-    return { income, expenditure, total };
-};

--- a/frontend/src/components/CalendarTable/index.jsx
+++ b/frontend/src/components/CalendarTable/index.jsx
@@ -3,15 +3,16 @@ import { useRecoilValue } from 'recoil';
 import { nanoid } from 'nanoid';
 
 import Week from './Week';
+import { useWeek } from './hooks';
+import { useTransactionSummary } from '../../hooks/useTransactionSummary';
 import { transactionsInDateState } from '../../recoil/date/selector';
 import { WEEK_DAY } from '../../utils/constant/week';
 import { makeDailyTransaction } from '../../utils/common/make-daily-transaction';
-import { useWeek, useCost } from './hooks';
 import { DayBar, DayBox, MonthContainer, Footer, SummaryRow } from './style';
 
 const CalendarTable = () => {
     const { currentDate, baseDay, firstWeek, lastWeek } = useWeek();
-    const { income, expenditure, total } = useCost();
+    const { monthIncome, monthExpenditure, total } = useTransactionSummary();
     const rawTransactions = useRecoilValue(transactionsInDateState);
     const dailyTransactions = makeDailyTransaction(rawTransactions);
 
@@ -43,8 +44,8 @@ const CalendarTable = () => {
             <Footer>
                 <SummaryRow>
                     <td>
-                        <span>총 수입 {parseInt(income).toLocaleString()} </span>
-                        <span>총 지출 {parseInt(expenditure).toLocaleString()}</span>
+                        <span>총 수입 {parseInt(monthIncome).toLocaleString()} </span>
+                        <span>총 지출 {parseInt(monthExpenditure).toLocaleString()}</span>
                     </td>
                     <td>총계 {parseInt(total).toLocaleString()}</td>
                 </SummaryRow>

--- a/frontend/src/components/CalendarTable/test.js
+++ b/frontend/src/components/CalendarTable/test.js
@@ -4,7 +4,7 @@ import { render, screen } from '../../test-utils';
 import { renderHook } from '@testing-library/react-hooks';
 
 import CalendarTable from './index';
-import { useWeek, useCost } from './hooks';
+import { useWeek } from './hooks';
 import { dateState } from '../../recoil/date/atom';
 import { WEEK_DAY } from '../../utils/constant/week';
 import { transactionsWithDate } from '../../mocks/transactions';
@@ -42,16 +42,5 @@ describe('달력을 표시하는 CalendarTable 컴포넌트 테스트', () => {
         const { firstWeek, lastWeek } = result.current;
         expect(firstWeek).toEqual(FIRST_WEEK);
         expect(lastWeek).toEqual(LAST_WEEK);
-    });
-
-    it('useCost - 현재 날짜에 해당하는 거래내역의 수입, 지출, 총계를 반환한다.', async () => {
-        const { result, waitForNextUpdate } = renderHook(() => useCost(), { wrapper: Wrapper });
-
-        await waitForNextUpdate();
-
-        const { income, expenditure, total } = result.current;
-        expect(income).toEqual(INCOME);
-        expect(expenditure).toEqual(EXPENDITURE);
-        expect(total).toEqual(TOTAL);
     });
 });

--- a/frontend/src/components/Donut/index.jsx
+++ b/frontend/src/components/Donut/index.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { nanoid } from 'nanoid';
+
+import { DonutCircle } from './style';
+
+const [CX, CY, R, WIDTH, START_ANGLE] = [50, 50, 30, 15, -90];
+const [CATEGORY_INDEX, COST_INDEX] = [0, 1];
+const ANIMATION_DURATION = 1000;
+
+const Donut = ({ transactionsByCategory }) => {
+    const dashArray = 2 * Math.PI * R;
+    let accumulatePercent = 0;
+
+    const circles = Array.from(transactionsByCategory.entries())
+        .sort((a, b) => b[COST_INDEX].percent - a[COST_INDEX].percent)
+        .map((percentWithCategory) => {
+            const color = percentWithCategory[CATEGORY_INDEX].color;
+            const percent = percentWithCategory[COST_INDEX].percent;
+
+            const dashOffset = dashArray - (dashArray * percent) / 100;
+            const angle = (accumulatePercent * 360) / 100 + START_ANGLE;
+            const currentDuration = (ANIMATION_DURATION * percent) / 100;
+            const delay = (ANIMATION_DURATION * accumulatePercent) / 100;
+            accumulatePercent += percent;
+            return (
+                <DonutCircle
+                    key={nanoid()}
+                    cx={CX}
+                    cy={CY}
+                    r={R}
+                    fill={'transparent'}
+                    color={color}
+                    width={WIDTH}
+                    dashArray={dashArray}
+                    dashOffset={dashOffset}
+                    angle={angle}
+                    currentDuration={currentDuration}
+                    delay={delay}
+                />
+            );
+        });
+
+    return <svg viewBox="0 0 100 100">{circles}</svg>;
+};
+
+export default Donut;

--- a/frontend/src/components/Donut/index.jsx
+++ b/frontend/src/components/Donut/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { nanoid } from 'nanoid';
 
-import { DonutCircle } from './style';
+import { Wrapper, DonutCircle } from './style';
 
 const [CX, CY, R, WIDTH, START_ANGLE] = [50, 50, 30, 15, -90];
 const [CATEGORY_INDEX, COST_INDEX] = [0, 1];
@@ -40,7 +40,11 @@ const Donut = ({ transactionsByCategory }) => {
             );
         });
 
-    return <svg viewBox="0 0 100 100">{circles}</svg>;
+    return (
+        <Wrapper>
+            <svg viewBox="0 0 100 100">{circles}</svg>
+        </Wrapper>
+    );
 };
 
 export default Donut;

--- a/frontend/src/components/Donut/style.js
+++ b/frontend/src/components/Donut/style.js
@@ -1,5 +1,15 @@
 import styled, { keyframes } from 'styled-components';
 
+import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
+
+export const Wrapper = styled.div`
+    width: 50%;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 100%;
+    }
+`;
+
 const draw = (dashOffset) => keyframes`
     100% {
             stroke-dashoffset: ${dashOffset};

--- a/frontend/src/components/Donut/style.js
+++ b/frontend/src/components/Donut/style.js
@@ -1,0 +1,24 @@
+import styled, { keyframes } from 'styled-components';
+
+const draw = (dashOffset) => keyframes`
+    100% {
+            stroke-dashoffset: ${dashOffset};
+    }
+`;
+
+export const DonutCircle = styled.circle`
+    cx: ${(props) => props.cx};
+    cy: ${(props) => props.cy};
+    r: ${(props) => props.r};
+    fill: ${(props) => props.fill};
+
+    stroke: ${(props) => props.color};
+    stroke-width: ${(props) => props.width};
+    stroke-dasharray: ${(props) => props.dashArray};
+    stroke-dashoffset: ${(props) => props.dashArray};
+    transform: rotate(${(props) => props.angle}deg);
+    transform-origin: ${(props) => props.cx}px ${(props) => props.cy}px;
+
+    animation: ${(props) => draw(props.dashOffset)} ${(props) => props.currentDuration}ms
+        ${(props) => props.delay}ms linear forwards;
+`;

--- a/frontend/src/components/StatisticsContent/index.jsx
+++ b/frontend/src/components/StatisticsContent/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { nanoid } from 'nanoid';
+
+import { Wrapper, OuterBox, InnerBox, Category, Content, Cost } from './style';
+
+const [CATEGORY_INDEX, COST_INDEX] = [0, 1];
+
+const StatisticsContent = ({ transactionsByCategory }) => {
+    const summaryByCategory = Array.from(transactionsByCategory.entries())
+        .sort((a, b) => b[COST_INDEX].percent - a[COST_INDEX].percent)
+        .map((percentWithCategory) => {
+            const { name, color } = percentWithCategory[CATEGORY_INDEX];
+            const { percent, expenditureInCategory } = percentWithCategory[COST_INDEX];
+            return expenditureInCategory !== 0 ? (
+                <OuterBox key={nanoid()}>
+                    <InnerBox>
+                        <Category color={color}>{name}</Category>
+                        <Content>{Math.ceil(percent)}%</Content>
+                    </InnerBox>
+                    <Cost>{parseInt(expenditureInCategory).toLocaleString()}</Cost>
+                </OuterBox>
+            ) : null;
+        });
+
+    return <Wrapper>{summaryByCategory}</Wrapper>;
+};
+
+export default StatisticsContent;

--- a/frontend/src/components/StatisticsContent/style.js
+++ b/frontend/src/components/StatisticsContent/style.js
@@ -11,7 +11,7 @@ export const Wrapper = styled.ul`
 `;
 
 export const OuterBox = styled.li`
-    width: 100%;
+    width: 90%;
     padding: 10px;
 
     display: flex;
@@ -28,6 +28,7 @@ export const OuterBox = styled.li`
     }
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 100%;
         padding: 10px 0px;
     }
 `;

--- a/frontend/src/components/StatisticsContent/style.js
+++ b/frontend/src/components/StatisticsContent/style.js
@@ -1,0 +1,87 @@
+import styled from 'styled-components';
+
+import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
+
+export const Wrapper = styled.ul`
+    width: 50%;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 100%;
+    }
+`;
+
+export const OuterBox = styled.li`
+    width: 100%;
+    padding: 10px;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    border-bottom: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
+
+    &:hover {
+        transform: scale(1.01);
+        background: ${({ theme }) => theme.color.brigtenL2Gray};
+        cursor: pointer;
+    }
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        padding: 10px 0px;
+    }
+`;
+
+export const InnerBox = styled.div`
+    width: 200px;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+`;
+
+export const Category = styled.span`
+    width: 100px;
+    padding: 5px 0px;
+
+    text-align: center;
+
+    border-radius: 999px;
+    box-sizing: border-box;
+
+    color: ${({ theme }) => theme.color.white};
+    background-color: ${(props) => props.color};
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 70px;
+
+        font-size: ${({ theme }) => theme.fontSize.mini};
+    }
+`;
+
+export const Content = styled.span`
+    width: 30px;
+    margin-left: 20px;
+
+    color: ${({ theme }) => theme.color.gray};
+`;
+
+export const Cost = styled.span`
+    width: calc(100% - 140px);
+
+    text-align: right;
+    font-weight: bold;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: calc(100% - 100px);
+    }
+`;

--- a/frontend/src/components/StatisticsContent/test.js
+++ b/frontend/src/components/StatisticsContent/test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '../../test-utils';
+
+import StatisticsContent from '.';
+
+const [CATEGORY_INDEX, COST_INDEX] = [0, 1];
+const TEST_DATA = new Map();
+TEST_DATA.set(
+    { id: 1, name: '식비', color: '#4CA1DE', sign: '-' },
+    { percent: 82, expenditureInCategory: 42000 },
+);
+TEST_DATA.set(
+    { id: 2, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { percent: 18, expenditureInCategory: 9400 },
+);
+
+describe('카테고리 별 지출 내역의 비율과 금액을 표시하는 StatisticsContent 컴포넌트 테스트', () => {
+    it('카테고리 별 이름, 지출 내역의 비율과 금액을 표시한다.', () => {
+        render(<StatisticsContent transactionsByCategory={TEST_DATA} />);
+        const categories = screen.getAllByRole('listitem');
+        expect(categories).toHaveLength(2);
+
+        Array.from(TEST_DATA.entries()).map((data, index) => {
+            const { name } = data[CATEGORY_INDEX];
+            const { percent, expenditureInCategory } = data[COST_INDEX];
+            expect(categories[index]).toHaveTextContent(name);
+            expect(categories[index]).toHaveTextContent(percent);
+            expect(categories[index]).toHaveTextContent(
+                parseInt(expenditureInCategory).toLocaleString(),
+            );
+        });
+    });
+});

--- a/frontend/src/components/Summary/index.jsx
+++ b/frontend/src/components/Summary/index.jsx
@@ -9,7 +9,7 @@ import { SummaryContainer, SummaryBox } from './style';
 
 const Summary = () => {
     const [check, setCheck] = useRecoilState(checkState);
-    const [transactionCount, monthIncome, monthExpenditure] = useTransactionSummary();
+    const { transactionCount, monthIncome, monthExpenditure } = useTransactionSummary();
 
     // TODO 체크박스 전역 상태관리 필요할듯함 + label 안에 input 넣는 식으로 변경?
     return (

--- a/frontend/src/hooks/useTransactionSummary.js
+++ b/frontend/src/hooks/useTransactionSummary.js
@@ -5,11 +5,12 @@ import { transactionsInDateState } from '../recoil/date/selector';
 import { calculateIncome, calculateExpenditure } from '../utils/common/calculate-cost';
 
 export const useTransactionSummary = () => {
-    const rawTransactions = useRecoilValue(transactionsInDateState);
+    const transactions = useRecoilValue(transactionsInDateState);
 
-    const transactionCount = rawTransactions.length;
-    const monthIncome = calculateIncome(rawTransactions);
-    const monthExpenditure = calculateExpenditure(rawTransactions);
+    const transactionCount = transactions.length;
+    const monthIncome = calculateIncome(transactions);
+    const monthExpenditure = calculateExpenditure(transactions);
+    const total = monthIncome - monthExpenditure;
 
-    return [transactionCount, monthIncome, monthExpenditure];
+    return { transactions, transactionCount, monthIncome, monthExpenditure, total };
 };

--- a/frontend/src/mocks/transactions.js
+++ b/frontend/src/mocks/transactions.js
@@ -148,9 +148,9 @@ export const transactionsWithDate = {
             date: '2022-01-28',
         },
         {
-            category: '카페/간식',
-            color: '#D092E2',
-            content: '민트초코라떼',
+            category: '식비',
+            color: '#4CA1DE',
+            content: '우동',
             method: '현금',
             sign: '-',
             cost: '5200',

--- a/frontend/src/pages/Statistics/hooks.js
+++ b/frontend/src/pages/Statistics/hooks.js
@@ -1,0 +1,22 @@
+import { useRecoilValue } from 'recoil';
+
+import { useTransactionSummary } from '../../hooks/useTransactionSummary';
+import { filteredCategoryState } from '../../recoil/category/selector';
+import { calculateExpenditure } from '../../utils/common/calculate-cost';
+
+export const useTransactionByCategory = () => {
+    const categories = useRecoilValue(filteredCategoryState);
+    const { transactions, monthExpenditure } = useTransactionSummary();
+
+    const transactionsByCategory = new Map();
+    categories.forEach((category) => {
+        const transactionsInCategory = transactions.filter(
+            (transaction) => transaction.category === category.name,
+        );
+        const expenditureInCategory = calculateExpenditure(transactionsInCategory);
+        const percent = (expenditureInCategory / monthExpenditure) * 100;
+        transactionsByCategory.set(category, { percent, expenditureInCategory });
+    });
+
+    return { transactionsByCategory };
+};

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -1,15 +1,12 @@
 import React, { Suspense } from 'react';
 import { useRecoilValue } from 'recoil';
-import { nanoid } from 'nanoid';
 
 import Header from '../../components/Header';
+import Donut from '../../components/Donut';
 import { useTransactionSummary } from '../../hooks/useTransactionSummary';
 import { filteredCategoryState } from '../../recoil/category/selector';
 import { calculateExpenditure } from '../../utils/common/calculate-cost';
-import { MainWrapper, DonutCircle } from './style';
-
-const CATEGORY_INDEX = 0;
-const COST_INDEX = 1;
+import { MainWrapper } from './style';
 
 const Statistics = () => {
     const categories = useRecoilValue(filteredCategoryState);
@@ -25,44 +22,11 @@ const Statistics = () => {
         transactionsByCategory.set(category, { percent, expenditureInCategory });
     });
 
-    const [cx, cy, r, width, startAngle] = [50, 50, 30, 15, -90];
-    const dashArray = 2 * Math.PI * r;
-    const animationDuration = 1000;
-    let accumulatePercent = 0;
-    const circles = Array.from(transactionsByCategory.entries())
-        .sort((a, b) => b[COST_INDEX].percent - a[COST_INDEX].percent)
-        .map((percentWithCategory) => {
-            const color = percentWithCategory[CATEGORY_INDEX].color;
-            const percent = percentWithCategory[COST_INDEX].percent;
-
-            const dashOffset = dashArray - (dashArray * percent) / 100;
-            const angle = (accumulatePercent * 360) / 100 + startAngle;
-            const currentDuration = (animationDuration * percent) / 100;
-            const delay = (animationDuration * accumulatePercent) / 100;
-            accumulatePercent += percent;
-            return (
-                <DonutCircle
-                    key={nanoid()}
-                    cx={cx}
-                    cy={cy}
-                    r={r}
-                    fill={'transparent'}
-                    color={color}
-                    width={width}
-                    dashArray={dashArray}
-                    dashOffset={dashOffset}
-                    angle={angle}
-                    currentDuration={currentDuration}
-                    delay={delay}
-                />
-            );
-        });
-
     return (
         <Suspense fallback={<div>Loading...</div>}>
             <Header current={'statistics'} />
             <MainWrapper>
-                <svg viewBox="0 0 100 100">{circles}</svg>
+                <Donut transactionsByCategory={transactionsByCategory} />
             </MainWrapper>
         </Suspense>
     );

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -1,32 +1,22 @@
 import React, { Suspense } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import Header from '../../components/Header';
 import Donut from '../../components/Donut';
-import { useTransactionSummary } from '../../hooks/useTransactionSummary';
-import { filteredCategoryState } from '../../recoil/category/selector';
-import { calculateExpenditure } from '../../utils/common/calculate-cost';
-import { MainWrapper } from './style';
+import StatisticsContent from '../../components/StatisticsContent';
+import { useTransactionByCategory } from './hooks';
+import { MainWrapper, DonutBox } from './style';
 
 const Statistics = () => {
-    const categories = useRecoilValue(filteredCategoryState);
-    const { transactions, monthExpenditure } = useTransactionSummary();
-
-    const transactionsByCategory = new Map();
-    categories.forEach((category) => {
-        const transactionsInCategory = transactions.filter(
-            (transaction) => transaction.category === category.name,
-        );
-        const expenditureInCategory = calculateExpenditure(transactionsInCategory);
-        const percent = (expenditureInCategory / monthExpenditure) * 100;
-        transactionsByCategory.set(category, { percent, expenditureInCategory });
-    });
+    const { transactionsByCategory } = useTransactionByCategory();
 
     return (
         <Suspense fallback={<div>Loading...</div>}>
             <Header current={'statistics'} />
             <MainWrapper>
-                <Donut transactionsByCategory={transactionsByCategory} />
+                <DonutBox>
+                    <Donut transactionsByCategory={transactionsByCategory} />
+                    <StatisticsContent transactionsByCategory={transactionsByCategory} />
+                </DonutBox>
             </MainWrapper>
         </Suspense>
     );

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -9,7 +9,7 @@ import { calculateExpenditure } from '../../utils/common/calculate-cost';
 import { MainWrapper, DonutCircle } from './style';
 
 const CATEGORY_INDEX = 0;
-const PERCENT_INDEX = 1;
+const COST_INDEX = 1;
 
 const Statistics = () => {
     const categories = useRecoilValue(filteredCategoryState);
@@ -22,7 +22,7 @@ const Statistics = () => {
         );
         const expenditureInCategory = calculateExpenditure(transactionsInCategory);
         const percent = (expenditureInCategory / monthExpenditure) * 100;
-        transactionsByCategory.set(category, percent);
+        transactionsByCategory.set(category, { percent, expenditureInCategory });
     });
 
     const [cx, cy, r, width, startAngle] = [50, 50, 30, 15, -90];
@@ -30,10 +30,10 @@ const Statistics = () => {
     const animationDuration = 1000;
     let accumulatePercent = 0;
     const circles = Array.from(transactionsByCategory.entries())
-        .sort((a, b) => b[PERCENT_INDEX] - a[PERCENT_INDEX])
+        .sort((a, b) => b[COST_INDEX].percent - a[COST_INDEX].percent)
         .map((percentWithCategory) => {
             const color = percentWithCategory[CATEGORY_INDEX].color;
-            const percent = percentWithCategory[PERCENT_INDEX];
+            const percent = percentWithCategory[COST_INDEX].percent;
 
             const dashOffset = dashArray - (dashArray * percent) / 100;
             const angle = (accumulatePercent * 360) / 100 + startAngle;

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -1,56 +1,62 @@
 import React, { Suspense } from 'react';
+import { useRecoilValue } from 'recoil';
 import { nanoid } from 'nanoid';
 
 import Header from '../../components/Header';
+import { useTransactionSummary } from '../../hooks/useTransactionSummary';
+import { filteredCategoryState } from '../../recoil/category/selector';
+import { calculateExpenditure } from '../../utils/common/calculate-cost';
 import { MainWrapper, DonutCircle } from './style';
 
+const CATEGORY_INDEX = 0;
+const PERCENT_INDEX = 1;
+
 const Statistics = () => {
-    const datas = [
-        {
-            percent: 37,
-            color: '#80e080',
-        },
-        {
-            percent: 33,
-            color: '#4fc3f7',
-        },
-        {
-            percent: 20,
-            color: '#9575cd',
-        },
-        {
-            percent: 10,
-            color: '#f06292',
-        },
-    ];
+    const categories = useRecoilValue(filteredCategoryState);
+    const { transactions, monthExpenditure } = useTransactionSummary();
+
+    const transactionsByCategory = new Map();
+    categories.forEach((category) => {
+        const transactionsInCategory = transactions.filter(
+            (transaction) => transaction.category === category.name,
+        );
+        const expenditureInCategory = calculateExpenditure(transactionsInCategory);
+        const percent = (expenditureInCategory / monthExpenditure) * 100;
+        transactionsByCategory.set(category, percent);
+    });
 
     const [cx, cy, r, width, startAngle] = [50, 50, 30, 15, -90];
     const dashArray = 2 * Math.PI * r;
     const animationDuration = 1000;
     let accumulatePercent = 0;
-    const circles = datas.map((data) => {
-        const dashOffset = dashArray - (dashArray * data.percent) / 100;
-        const angle = (accumulatePercent * 360) / 100 + startAngle;
-        const currentDuration = (animationDuration * data.percent) / 100;
-        const delay = (animationDuration * accumulatePercent) / 100;
-        accumulatePercent += data.percent;
-        return (
-            <DonutCircle
-                key={nanoid()}
-                cx={cx}
-                cy={cy}
-                r={r}
-                fill={'transparent'}
-                color={data.color}
-                width={width}
-                dashArray={dashArray}
-                dashOffset={dashOffset}
-                angle={angle}
-                currentDuration={currentDuration}
-                delay={delay}
-            />
-        );
-    });
+    const circles = Array.from(transactionsByCategory.entries())
+        .sort((a, b) => b[PERCENT_INDEX] - a[PERCENT_INDEX])
+        .map((percentWithCategory) => {
+            const color = percentWithCategory[CATEGORY_INDEX].color;
+            const percent = percentWithCategory[PERCENT_INDEX];
+
+            const dashOffset = dashArray - (dashArray * percent) / 100;
+            const angle = (accumulatePercent * 360) / 100 + startAngle;
+            const currentDuration = (animationDuration * percent) / 100;
+            const delay = (animationDuration * accumulatePercent) / 100;
+            accumulatePercent += percent;
+            return (
+                <DonutCircle
+                    key={nanoid()}
+                    cx={cx}
+                    cy={cy}
+                    r={r}
+                    fill={'transparent'}
+                    color={color}
+                    width={width}
+                    dashArray={dashArray}
+                    dashOffset={dashOffset}
+                    angle={angle}
+                    currentDuration={currentDuration}
+                    delay={delay}
+                />
+            );
+        });
 
     return (
         <Suspense fallback={<div>Loading...</div>}>

--- a/frontend/src/pages/Statistics/style.js
+++ b/frontend/src/pages/Statistics/style.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 
 export const MainWrapper = styled.div`
     width: 100vw;
@@ -9,27 +9,4 @@ export const MainWrapper = styled.div`
     flex-direction: column;
     justify-content: flex-start;
     align-items: center;
-`;
-
-const draw = (dashOffset) => keyframes`
-    100% {
-            stroke-dashoffset: ${dashOffset};
-    }
-`;
-
-export const DonutCircle = styled.circle`
-    cx: ${(props) => props.cx};
-    cy: ${(props) => props.cy};
-    r: ${(props) => props.r};
-    fill: ${(props) => props.fill};
-
-    stroke: ${(props) => props.color};
-    stroke-width: ${(props) => props.width};
-    stroke-dasharray: ${(props) => props.dashArray};
-    stroke-dashoffset: ${(props) => props.dashArray};
-    transform: rotate(${(props) => props.angle}deg);
-    transform-origin: ${(props) => props.cx}px ${(props) => props.cy}px;
-
-    animation: ${(props) => draw(props.dashOffset)} ${(props) => props.currentDuration}ms
-        ${(props) => props.delay}ms linear forwards;
 `;

--- a/frontend/src/pages/Statistics/style.js
+++ b/frontend/src/pages/Statistics/style.js
@@ -15,16 +15,27 @@ export const MainWrapper = styled.div`
 
 export const DonutBox = styled.div`
     width: 70%;
+    margin-top: -20px;
 
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;
     align-items: center;
 
+    border: 1px solid ${({ theme }) => theme.color.brigtenL1Gray};
+    background: ${({ theme }) => theme.color.white};
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+    border-radius: 10px;
+
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 90%;
 
         flex-direction: column;
         justify-content: flex-start;
+
+        border: none;
+        background: none;
+        box-shadow: none;
+        border-radius: none;
     }
 `;

--- a/frontend/src/pages/Statistics/style.js
+++ b/frontend/src/pages/Statistics/style.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { MAX_MOBILE_DEVICE } from '../../utils/constant/device-size';
+
 export const MainWrapper = styled.div`
     width: 100vw;
     height: calc(100vh - 125px);
@@ -9,4 +11,20 @@ export const MainWrapper = styled.div`
     flex-direction: column;
     justify-content: flex-start;
     align-items: center;
+`;
+
+export const DonutBox = styled.div`
+    width: 70%;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
+
+    @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        width: 90%;
+
+        flex-direction: column;
+        justify-content: flex-start;
+    }
 `;

--- a/frontend/src/pages/Statistics/test.js
+++ b/frontend/src/pages/Statistics/test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useTransactionByCategory } from './hooks';
+import { dateState } from '../../recoil/date/atom';
+import { categoryState } from '../../recoil/category/atom';
+
+const TEST_CATEGORY = [
+    { id: 1, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { id: 2, name: '식비', color: '#4CA1DE', sign: '-' },
+];
+
+const TEST_DATA = new Map();
+TEST_DATA.set(
+    { id: 1, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { percent: 67.90123456790124, expenditureInCategory: 11000 },
+);
+TEST_DATA.set(
+    { id: 2, name: '식비', color: '#4CA1DE', sign: '-' },
+    { percent: 32.098765432098766, expenditureInCategory: 5200 },
+);
+
+describe('통계페이지에 사용되는 커스텀 hooks 테스트', () => {
+    const initializeState = ({ set }) => {
+        set(dateState, {
+            year: 2022,
+            month: 1,
+        });
+        set(categoryState, TEST_CATEGORY);
+    };
+
+    const Wrapper = ({ children }) => {
+        return <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>;
+    };
+
+    it('useTransactionByCategory - 카테고리 별 지출 비율 및 금액을 Map 형태로 반환한다.', async () => {
+        const { result, waitForNextUpdate } = renderHook(() => useTransactionByCategory(), {
+            wrapper: Wrapper,
+        });
+        await waitForNextUpdate();
+        const { transactionsByCategory } = result.current;
+        expect(transactionsByCategory).toEqual(TEST_DATA);
+    });
+});

--- a/frontend/src/recoil/category/selector.js
+++ b/frontend/src/recoil/category/selector.js
@@ -1,0 +1,12 @@
+import { selector } from 'recoil';
+
+import { categoryState } from './atom';
+
+export const filteredCategoryState = selector({
+    key: 'filteredCategoryState',
+    get: ({ get }) => {
+        const categories = get(categoryState);
+        const filterdCategories = categories.filter((category) => category.sign === '-');
+        return filterdCategories;
+    },
+});

--- a/frontend/src/recoil/category/test.js
+++ b/frontend/src/recoil/category/test.js
@@ -1,0 +1,33 @@
+import { snapshot_UNSTABLE } from 'recoil';
+
+import { categoryState } from './atom';
+import { filteredCategoryState } from './selector';
+
+const TEST_DATA = [
+    { id: 1, name: '미분류', color: '#817DCE', sign: 'all' },
+    { id: 2, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { id: 4, name: '용돈', color: '#E6D267', sign: '+' },
+    { id: 5, name: '교통', color: '#94D3CC', sign: '-' },
+    { id: 10, name: '월급', color: '#B9D58C', sign: '+' },
+    { id: 13, name: '식비', color: '#4CA1DE', sign: '-' },
+    { id: 14, name: '여행/숙박', color: '#E2B765', sign: '-' },
+    { id: 28, name: '여가/취미', color: '#B9D58C', sign: '-' },
+    { id: 29, name: '교육', color: '#F4A460', sign: '-' },
+];
+
+const INCOME_DATA = [
+    { id: 2, name: '카페/간식', color: '#D092E2', sign: '-' },
+    { id: 5, name: '교통', color: '#94D3CC', sign: '-' },
+    { id: 13, name: '식비', color: '#4CA1DE', sign: '-' },
+    { id: 14, name: '여행/숙박', color: '#E2B765', sign: '-' },
+    { id: 28, name: '여가/취미', color: '#B9D58C', sign: '-' },
+    { id: 29, name: '교육', color: '#F4A460', sign: '-' },
+];
+
+describe('category Selectors 테스트', () => {
+    it('filteredCategoryState(수입 카테고리 영역만 필터링해주는) Selector 테스트', async () => {
+        const testSnapshot = snapshot_UNSTABLE(({ set }) => set(categoryState, TEST_DATA));
+        const result = testSnapshot.getLoadable(filteredCategoryState).valueOrThrow();
+        expect(result).toEqual(INCOME_DATA);
+    });
+});


### PR DESCRIPTION
### PC 버전 
![image](https://user-images.githubusercontent.com/67899069/154319304-af4c53a5-0452-4da3-9444-bd60977395f6.png)

### 모바일 버전(iPhone SE)
![image](https://user-images.githubusercontent.com/67899069/154319358-90e9cc1b-c954-4aa7-9db6-0dd35dbcbe61.png)

## 구현한 내용
* 실제데이터를 기반으로 도넛차트를 그리는 로직을 구현했습니다.
 * 카테고리 별 지출 비율과 금액을 렌더링하는 로직을 구현했습니다.
    * 도넛차트와 카테고리 별 금액을 나타내는 컴포넌트는 하나의 flex box로 묶입니다.
    * 데스크탑, 모바일 버전에 따라 배치가 달라집니다.
    * 데스크탑의 경우 row, 모바일의 경우  column 형태가 됩니다.

## 체크리스트
- [x]  PC, 모바일 버전에 맞춰서 반응형 웹 구현하기
- [x] 프론트엔드 Test Code 작성하기
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지