### PR TITLE
[Sprint 2] fetch 요청 후 에러발생 시 alert 띄우는 로직 추가

### DIFF
--- a/frontend/src/lib/category.js
+++ b/frontend/src/lib/category.js
@@ -11,8 +11,8 @@ export const getCategories = async () => {
 
         return response.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('카테고리를 불러오는데 실패했습니다.');
     }
 };
 
@@ -28,8 +28,13 @@ export const createCategory = async (name, color, sign) => {
 
         return response.data.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기(409인 경우 중복된 name이라고 띄우기)
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        const statusCode = e.response.status;
+        if (statusCode === 409) {
+            alert('중복된 카테고리입니다.');
+            return;
+        }
+        alert('카테고리를 추가하는데 실패했습니다.');
     }
 };
 
@@ -39,7 +44,7 @@ export const deleteCategory = async (id) => {
         const COMPLETE = result.status === 200;
         return COMPLETE;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('카테고리를 삭제하는데 실패했습니다.');
     }
 };

--- a/frontend/src/lib/method.js
+++ b/frontend/src/lib/method.js
@@ -9,7 +9,7 @@ export const getMethods = async () => {
         const response = await instance.get('/');
         return response.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('결제수단을 가져오는데 실패했습니다.');
     }
 };

--- a/frontend/src/lib/transaction.js
+++ b/frontend/src/lib/transaction.js
@@ -11,8 +11,8 @@ export const getTransactionsInDate = async (year, month) => {
         const response = await instance.get(`?year=${year}&month=${month}&nickname=${nickname}`);
         return response.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('거래내역을 가져오는데 실패했습니다.');
     }
 };
 
@@ -30,8 +30,8 @@ export const createTransaction = async (mid, cid, content, cost, sign, date) => 
         });
         return response.data.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('거래내역을 추가하는데 실패했습니다.');
     }
 };
 
@@ -48,8 +48,8 @@ export const updateTransaction = async (id, mid, cid, content, cost, sign, date)
         });
         return response.data.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('거래내역을 수정하는데 실패했습니다.');
     }
 };
 
@@ -59,7 +59,7 @@ export const deleteTransaction = async (id) => {
         const COMPLETE = result.status === 200;
         return COMPLETE;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('거래내역을 삭제하는데 실패했습니다.');
     }
 };

--- a/frontend/src/lib/user.js
+++ b/frontend/src/lib/user.js
@@ -12,7 +12,7 @@ export const postLogin = async (code) => {
         });
         return response.data.data;
     } catch (e) {
-        // TODO 에러 발생 알림창 띄우기
-        console.log(e);
+        // TODO UX를 고려해서 토스트 띄우는 것으로 변경하기
+        alert('로그인에 실패했습니다.');
     }
 };


### PR DESCRIPTION
## 구현한 내용
* fetch 요청 후 에러발생 시 alert 띄우는 로직을 추가했습니다.
    * UX 향상을 위해 alert창이 아닌 토스트를 이용하면 좋을 것 같습니다.
    * 카테고리의 경우 409 에러코드 반환 시 분기 처리합니다.
 * 추가, 삭제 성공 시에도 별도의 alert 로직을 추가할 필요가 있어보입니다.

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지