### PR TITLE
[로직 강화] 거래내역 추가, 수정, 삭제 시 기존의 데이터들도 최신화 되도록 구현

### DIFF
--- a/frontend/src/components/CalendarTable/hooks.js
+++ b/frontend/src/components/CalendarTable/hooks.js
@@ -2,8 +2,6 @@ import { useRecoilValue } from 'recoil';
 import moment from 'moment';
 
 import { dateState } from '../../recoil/date/atom';
-import { transactionsInDateState } from '../../recoil/date/selector';
-import { calculateIncome, calculateExpenditure } from '../../utils/common/calculate-cost';
 
 const OVER_WEEK = 53;
 

--- a/frontend/src/components/TransactionModal/hooks.js
+++ b/frontend/src/components/TransactionModal/hooks.js
@@ -42,7 +42,9 @@ export const useTransactionHandler = (closeModal) => {
         const transactionsInDate = JSON.parse(sessionStorage.getItem(transactionDate));
         const updatedTransactions = [...transactionsInDate, result];
         sessionStorage.setItem(transactionDate, JSON.stringify(updatedTransactions));
+
         closeModal('createTransaction');
+        closeModal('categoryTransaction');
         refreshTransaction();
     };
 
@@ -68,7 +70,9 @@ export const useTransactionHandler = (closeModal) => {
             (transaction) => transaction.id !== id,
         );
         sessionStorage.setItem(transactionDate, JSON.stringify([...updatedTransactions, result]));
+
         closeModal('updateTransaction');
+        closeModal('categoryTransaction');
         refreshTransaction();
     };
 
@@ -84,7 +88,9 @@ export const useTransactionHandler = (closeModal) => {
             (transaction) => transaction.id !== id,
         );
         sessionStorage.setItem(transactionDate, JSON.stringify(updatedTransactions));
+
         closeModal('updateTransaction');
+        closeModal('categoryTransaction');
         refreshTransaction();
     };
 

--- a/frontend/src/components/TransactionModal/hooks.js
+++ b/frontend/src/components/TransactionModal/hooks.js
@@ -1,5 +1,6 @@
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
+import { useRefreshTransaction } from '../../hooks/useRefreshTransaction';
 import { methodState } from '../../recoil/method/atom';
 import { categoryState } from '../../recoil/category/atom';
 import { createCategory } from '../../lib/category';
@@ -20,6 +21,7 @@ export const useCategory = (closeModal) => {
 export const useTransactionHandler = (closeModal) => {
     const methods = useRecoilValue(methodState);
     const categories = useRecoilValue(categoryState);
+    const { refreshTransaction } = useRefreshTransaction();
 
     const addTransaction = async ({ method, category, content, cost, sign, date }) => {
         const [year, month, _] = date.split('-');
@@ -41,6 +43,7 @@ export const useTransactionHandler = (closeModal) => {
         const updatedTransactions = [...transactionsInDate, result];
         sessionStorage.setItem(transactionDate, JSON.stringify(updatedTransactions));
         closeModal('createTransaction');
+        refreshTransaction();
     };
 
     const changeTransaction = async ({ id, method, category, content, cost, sign, date }) => {
@@ -66,6 +69,7 @@ export const useTransactionHandler = (closeModal) => {
         );
         sessionStorage.setItem(transactionDate, JSON.stringify([...updatedTransactions, result]));
         closeModal('updateTransaction');
+        refreshTransaction();
     };
 
     const removeTransaction = async (id, date) => {
@@ -81,6 +85,7 @@ export const useTransactionHandler = (closeModal) => {
         );
         sessionStorage.setItem(transactionDate, JSON.stringify(updatedTransactions));
         closeModal('updateTransaction');
+        refreshTransaction();
     };
 
     return { addTransaction, changeTransaction, removeTransaction };

--- a/frontend/src/components/TransactionModal/hooks.js
+++ b/frontend/src/components/TransactionModal/hooks.js
@@ -17,9 +17,31 @@ export const useCategory = (closeModal) => {
     return { addCategory };
 };
 
-export const useUpdateTransactionHandler = (closeModal) => {
+export const useTransactionHandler = (closeModal) => {
     const methods = useRecoilValue(methodState);
     const categories = useRecoilValue(categoryState);
+
+    const addTransaction = async ({ method, category, content, cost, sign, date }) => {
+        const [year, month, _] = date.split('-');
+        const transactionDate = `${year}-${month.replace(/(^0)+/i, '')}`;
+
+        const [methodInfo] = methods.filter((_method) => _method.name === method);
+        const [categoryInfo] = categories.filter((_category) => _category.name === category);
+        const result = await createTransaction(
+            methodInfo.id,
+            categoryInfo.id,
+            content,
+            cost,
+            sign,
+            date,
+        );
+        if (!result) return;
+
+        const transactionsInDate = JSON.parse(sessionStorage.getItem(transactionDate));
+        const updatedTransactions = [...transactionsInDate, result];
+        sessionStorage.setItem(transactionDate, JSON.stringify(updatedTransactions));
+        closeModal('createTransaction');
+    };
 
     const changeTransaction = async ({ id, method, category, content, cost, sign, date }) => {
         const [year, month, _] = date.split('-');
@@ -61,34 +83,5 @@ export const useUpdateTransactionHandler = (closeModal) => {
         closeModal('updateTransaction');
     };
 
-    return { changeTransaction, removeTransaction };
-};
-
-export const useCreateTransactionHandler = (closeModal) => {
-    const methods = useRecoilValue(methodState);
-    const categories = useRecoilValue(categoryState);
-
-    const addTransaction = async ({ method, category, content, cost, sign, date }) => {
-        const [year, month, _] = date.split('-');
-        const transactionDate = `${year}-${month.replace(/(^0)+/i, '')}`;
-
-        const [methodInfo] = methods.filter((_method) => _method.name === method);
-        const [categoryInfo] = categories.filter((_category) => _category.name === category);
-        const result = await createTransaction(
-            methodInfo.id,
-            categoryInfo.id,
-            content,
-            cost,
-            sign,
-            date,
-        );
-        if (!result) return;
-
-        const transactionsInDate = JSON.parse(sessionStorage.getItem(transactionDate));
-        const updatedTransactions = [...transactionsInDate, result];
-        sessionStorage.setItem(transactionDate, JSON.stringify(updatedTransactions));
-        closeModal('createTransaction');
-    };
-
-    return { addTransaction };
+    return { addTransaction, changeTransaction, removeTransaction };
 };

--- a/frontend/src/components/TransactionModal/index.jsx
+++ b/frontend/src/components/TransactionModal/index.jsx
@@ -4,14 +4,14 @@ import TransactionUpdateForm from '../TransactionUpdateForm';
 import TransactionCreateForm from '../TransactionCreateForm';
 import CategoryForm from '../CategoryCreateForm';
 import { useModal } from '../../hooks/useModal';
-import { useCategory, useUpdateTransactionHandler, useCreateTransactionHandler } from './hooks';
+import { useCategory, useTransactionHandler } from './hooks';
 import { Wrapper, BackgroundDim } from './style';
 
 const TransactionModal = () => {
     const { isOpen, closeModal, getOpenModalByName } = useModal();
     const { addCategory } = useCategory(closeModal);
-    const { changeTransaction, removeTransaction } = useUpdateTransactionHandler(closeModal);
-    const { addTransaction } = useCreateTransactionHandler(closeModal);
+    const { addTransaction, changeTransaction, removeTransaction } =
+        useTransactionHandler(closeModal);
 
     const transactionUpdateModal = getOpenModalByName('updateTransaction');
     const transactionCreateModal = getOpenModalByName('createTransaction');

--- a/frontend/src/hooks/useModal.js
+++ b/frontend/src/hooks/useModal.js
@@ -11,7 +11,7 @@ export const useModal = () => {
     };
 
     const closeModal = (name) => {
-        setModal(modals.filter((modal) => modal.name !== name));
+        setModal((prev) => prev.filter((_prev) => _prev.name !== name));
     };
 
     const getOpenModalByName = (name) => {

--- a/frontend/src/hooks/useRefreshTransaction.js
+++ b/frontend/src/hooks/useRefreshTransaction.js
@@ -1,0 +1,13 @@
+import { useRecoilRefresher_UNSTABLE } from 'recoil';
+
+import { transactionsInDateState } from '../recoil/date/selector';
+
+export const useRefreshTransaction = () => {
+    const refresh = useRecoilRefresher_UNSTABLE(transactionsInDateState);
+
+    const refreshTransaction = () => {
+        refresh();
+    };
+
+    return { refreshTransaction };
+};


### PR DESCRIPTION
## 구현한 내용
* 거래내역 추가, 삭제, 수정 시 기존의 참조하던 거래내역 데이터들을 최신화하는 로직을 구현했습니다.
   * 해당 로직을 구현하기 위해 useRecoilRefresher_UNSTABLE을 활용했습니다.
   * 해당 hook은 관련된 캐시를 지우기 위해 호출할 수 있는 콜백을 반환합니다.
   * 최신 데이터로 새로 고치거나 오류가 발생한 후 다시 시도하려는 경우에 유용하며, 이번 PR에서는 거래내역이 바뀌는 경우 날짜 기반으로 거래내역을 불러오는 transactionsInDateState Selector의 캐시를 초기화 하는데 사용했습니다.
(https://recoiljs.org/docs/api-reference/core/useRecoilRefresher/)

## 추가상식
1. selector의 set 함수에서는 async 비동기 로직을 지원하지 않습니다.
* 만약 비동기 로직을 적용하는 경우 아래와 같은 에러가 던져집니다.
```
export const shapedDateState = selector({
    key: 'shapedDateState',
    ...
    set: async ({ get, set }, newValue) => {
        const { year, month } = get(dateState);
        const { convertedYear, convertedMonth } = convertDate(year, month + newValue);
        set(dateState, { year: convertedYear, month: convertedMonth });

        const transactionsInDate = await get(transactionsInDateState);
        set(transactionState, transactionsInDate);
    },
});
```
```
Recoil: Async selector sets are not currently supported.
```

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지