### PR TITLE
[Issue Fix] 모바일에서 가상키보드가 올라올 경우 resize 이벤트 기반으로 새롭게 구한 height를 적용하는 Custom hook 구현

### DIFF
--- a/frontend/src/components/CategoryCreateForm/index.jsx
+++ b/frontend/src/components/CategoryCreateForm/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { useResizeHeight } from '../../hooks/useResizeHeight';
 import { useColor, useSumbit } from './hooks';
 import { CATEGORY_COLORS } from '../../utils/constant/category-color';
 import refreshImg from '../../../public/assets/refresh-button.svg';
@@ -18,6 +19,7 @@ import {
 
 const CategoryForm = ({ active, category, onCreate, onCancle }) => {
     const [sign, setSign] = useState(category ? category.sign : '+');
+    const { resizeHeight } = useResizeHeight();
     const { currentColor, changeColor } = useColor();
     const { handleUpdateSubmit } = useSumbit(onCreate);
 
@@ -26,6 +28,7 @@ const CategoryForm = ({ active, category, onCreate, onCancle }) => {
             aria-label="categoryCreate"
             active={active}
             onSubmit={(e) => handleUpdateSubmit(sign, e)}
+            mobileHeight={resizeHeight}
         >
             <CostType>
                 <TypeButton

--- a/frontend/src/components/CategoryCreateForm/style.js
+++ b/frontend/src/components/CategoryCreateForm/style.js
@@ -22,8 +22,10 @@ export const Wrapper = styled.form`
     box-shadow: ${({ theme }) => theme.shadow.thick};
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        position: absolute;
+
         width: 100vw;
-        height: 100vh;
+        height: ${(props) => (props.mobileHeight ? props.mobileHeight + 'px' : '100vh')};
         top: 0;
         left: 0;
         transform: none;
@@ -43,7 +45,7 @@ export const CostType = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 8vh;
+        height: 8%;
     }
 `;
 
@@ -73,7 +75,7 @@ export const Element = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 11vh;
+        height: 11%;
 
         justify-content: center;
     }
@@ -139,7 +141,7 @@ export const ButtonContainer = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 11vh;
+        height: 11%;
     }
 `;
 

--- a/frontend/src/components/TransactionCreateForm/index.jsx
+++ b/frontend/src/components/TransactionCreateForm/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import Dropdown from '../Dropdown';
-import back from '../../../public/assets/back-button.svg';
+import { useResizeHeight } from '../../hooks/useResizeHeight';
 import { useCreateForm } from './hooks';
+import back from '../../../public/assets/back-button.svg';
 import {
     Wrapper,
     CostType,
@@ -15,6 +16,7 @@ import {
 } from './style';
 
 const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
+    const { resizeHeight } = useResizeHeight();
     const [
         activeCategory,
         activeMethod,
@@ -36,7 +38,11 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
     ] = useCreateForm(transaction, onCreate);
 
     return (
-        <Wrapper aria-label="transactionCreate" onSubmit={handleCreateSubmit}>
+        <Wrapper
+            aria-label="transactionCreate"
+            onSubmit={handleCreateSubmit}
+            mobileHeight={resizeHeight}
+        >
             <Element>
                 <button type="button" aria-label="back" onClick={onCancle}>
                     <BackImg src={back} />

--- a/frontend/src/components/TransactionCreateForm/style.js
+++ b/frontend/src/components/TransactionCreateForm/style.js
@@ -22,8 +22,10 @@ export const Wrapper = styled.form`
     box-shadow: ${({ theme }) => theme.shadow.thick};
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        position: absolute;
+
         width: 100vw;
-        height: 100vh;
+        height: ${(props) => (props.mobileHeight ? props.mobileHeight + 'px' : '100vh')};
         top: 0;
         left: 0;
         transform: none;
@@ -43,7 +45,7 @@ export const CostType = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 8vh;
+        height: 8%;
     }
 `;
 
@@ -73,7 +75,7 @@ export const Element = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 11vh;
+        height: 11%;
 
         justify-content: center;
     }
@@ -105,7 +107,7 @@ export const ButtonContainer = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: 11vh;
+        height: 11%;
     }
 `;
 

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import Dropdown from '../Dropdown';
 import { useUpdateForm } from './hooks';
@@ -35,14 +35,35 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         openCategoryCreateModal,
     ] = useUpdateForm(transaction, onUpdate);
 
+    const [customHeight, setComstomHeight] = useState(null);
+
+    const updateHieght = () => {
+        if (customHeight == null) {
+            setComstomHeight(window.screen.availHeight);
+            return;
+        }
+        setComstomHeight(null);
+    };
+
+    useEffect(() => {
+        window.addEventListener('resize', updateHieght);
+        return () => {
+            window.removeEventListener('resize', updateHieght);
+        };
+    });
+
     return (
-        <Wrapper aria-label="transactionUpdate" onSubmit={handleUpdateSubmit}>
-            <Element mobileHeight={window.screen.height}>
+        <Wrapper
+            aria-label="transactionUpdate"
+            onSubmit={handleUpdateSubmit}
+            mobileHeight={customHeight}
+        >
+            <Element>
                 <button type="button" aria-label="back" onClick={onCancle}>
                     <BackImg src={back} />
                 </button>
             </Element>
-            <CostType mobileHeight={window.screen.height}>
+            <CostType>
                 <TypeButton
                     type="button"
                     aria-label="income"
@@ -60,7 +81,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     지출
                 </TypeButton>
             </CostType>
-            <Element mobileHeight={window.screen.height}>
+            <Element>
                 <label htmlFor="date">날짜</label>
                 <Input
                     type="text"
@@ -71,7 +92,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     onChange={changeDate}
                 />
             </Element>
-            <Element mobileHeight={window.screen.height}>
+            <Element>
                 <label htmlFor="category">카테고리</label>
                 <Input
                     type="text"
@@ -92,7 +113,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     createHandler={openCategoryCreateModal}
                 />
             </Element>
-            <Element mobileHeight={window.screen.height}>
+            <Element>
                 <label htmlFor="content">내용</label>
                 <Input
                     type="text"
@@ -103,7 +124,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     onChange={changeContent}
                 />
             </Element>
-            <Element mobileHeight={window.screen.height}>
+            <Element>
                 <label htmlFor="method">결제수단</label>
                 <Input
                     type="text"
@@ -122,7 +143,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     changeHandler={changeMethod}
                 />
             </Element>
-            <Element mobileHeight={window.screen.height}>
+            <Element>
                 <label htmlFor="cost">금액</label>
                 <Input
                     type="text"
@@ -133,7 +154,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
                     onChange={changeCost}
                 />
             </Element>
-            <ButtonContainer mobileHeight={window.screen.height}>
+            <ButtonContainer>
                 <DecisionButton
                     type="button"
                     action="delete"

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import Dropdown from '../Dropdown';
+import { useResizeHeight } from '../../hooks/useResizeHeight';
 import { useUpdateForm } from './hooks';
 import back from '../../../public/assets/back-button.svg';
 import {
@@ -15,6 +16,7 @@ import {
 } from './style';
 
 const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) => {
+    const { resizeHeight } = useResizeHeight();
     const [
         activeCategory,
         activeMethod,
@@ -35,28 +37,11 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         openCategoryCreateModal,
     ] = useUpdateForm(transaction, onUpdate);
 
-    const [customHeight, setComstomHeight] = useState(null);
-
-    const updateHieght = () => {
-        if (customHeight == null) {
-            setComstomHeight(window.screen.availHeight);
-            return;
-        }
-        setComstomHeight(null);
-    };
-
-    useEffect(() => {
-        window.addEventListener('resize', updateHieght);
-        return () => {
-            window.removeEventListener('resize', updateHieght);
-        };
-    });
-
     return (
         <Wrapper
             aria-label="transactionUpdate"
             onSubmit={handleUpdateSubmit}
-            mobileHeight={customHeight}
+            mobileHeight={resizeHeight}
         >
             <Element>
                 <button type="button" aria-label="back" onClick={onCancle}>

--- a/frontend/src/components/TransactionUpdateForm/style.js
+++ b/frontend/src/components/TransactionUpdateForm/style.js
@@ -22,9 +22,10 @@ export const Wrapper = styled.form`
     box-shadow: ${({ theme }) => theme.shadow.thick};
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
+        position: absolute;
+
         width: 100vw;
-        height: 100vh;
-        max-height: 100vh;
+        height: ${(props) => (props.mobileHeight ? props.mobileHeight + 'px' : '100vh')};
         top: 0;
         left: 0;
         transform: none;
@@ -45,8 +46,8 @@ export const CostType = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: ${(props) => (props.mobileHeight * 8) / 100}px;
-        min-height: ${(props) => (props.mobileHeight * 8) / 100}px;
+        height: 8%;
+        min-height: 8%;
     }
 `;
 
@@ -76,8 +77,8 @@ export const Element = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: ${(props) => (props.mobileHeight * 11) / 100}px;
-        min-height: ${(props) => (props.mobileHeight * 11) / 100}px;
+        height: 11%;
+        min-height: 11%;
 
         justify-content: center;
     }
@@ -109,8 +110,8 @@ export const ButtonContainer = styled.div`
 
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
-        height: ${(props) => (props.mobileHeight * 11) / 100}px;
-        min-height: ${(props) => (props.mobileHeight * 11) / 100}px;
+        height: 11%;
+        min-height: 11%;
     }
 `;
 

--- a/frontend/src/components/TransactionUpdateForm/style.js
+++ b/frontend/src/components/TransactionUpdateForm/style.js
@@ -29,7 +29,6 @@ export const Wrapper = styled.form`
         top: 0;
         left: 0;
         transform: none;
-        overflow-y: auto;
 
         justify-content: space-evenly;
 
@@ -47,7 +46,6 @@ export const CostType = styled.div`
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
         height: 8%;
-        min-height: 8%;
     }
 `;
 
@@ -78,7 +76,6 @@ export const Element = styled.div`
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
         height: 11%;
-        min-height: 11%;
 
         justify-content: center;
     }
@@ -111,7 +108,6 @@ export const ButtonContainer = styled.div`
     @media screen and (max-width: ${MAX_MOBILE_DEVICE}px) {
         width: 80vw;
         height: 11%;
-        min-height: 11%;
     }
 `;
 

--- a/frontend/src/hooks/useResizeHeight.js
+++ b/frontend/src/hooks/useResizeHeight.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+export const useResizeHeight = () => {
+    const [resizeHeight, setResizeHeight] = useState(null);
+
+    const updateHieght = () => {
+        if (resizeHeight == null) {
+            setResizeHeight(window.screen.availHeight);
+            return;
+        }
+        setResizeHeight(null);
+    };
+
+    useEffect(() => {
+        window.addEventListener('resize', updateHieght);
+        return () => {
+            window.removeEventListener('resize', updateHieght);
+        };
+    });
+
+    return { resizeHeight };
+};


### PR DESCRIPTION
## 구현한 내용
1. 가상키보드가 올라오는 경우 form의 요소 중 상단의 일부요소들이 짤리는 이슈 fix
* 이전에 구현한 내용 중 가상키보드가 올라오는 경우에 대비해서 미리 값을 screen.height을 줌으로써 form 요소들이 찌그러지는 것을 방지하고자 했습니다.
* 하지만, form의 요소들이 찌그러지지는 않더라도 상단의 일부요소가 짤리는 이슈가 발생했습니다.
* 이러한 이슈는 form요소들을 wrapping하는 요소의 position이 fixed로 설정이 되어있었기 때문에 상단으로 넘어가 요소를 제외한 일부요소만 scroll로 사용자의 눈으로 확인할 수 있었습니다.
* 이 부분은 미디어쿼리를 이용해서 모바일의 경우에만 position을 absolute로 변경함으로써, 키보드가 올라오는 경우 form의 모든 요소들을 scroll로 확인할 수 있었습니다.
2. 가상 키보드가 올라오는 경우 Viewport의 높이가 아닌 기기의 해상도(높이)를 구하는 로직 Custom hook으로 구현
* 기존에는 form의 요소들 각각 screen.height과 같은 요소들을 default로 부여하고, 그 값을 기준으로 높이를 설정했습니다.
* 하지만 screen.height의 경우에는 일반적인 vh에서 사용되는 Viewport의 기준이 아닌 기기의 하단 메뉴바와 같은 기기 자체의 해상도를 의미했기 때문에 의도치 않게 높이가 설정되어서 불필요하게 scroll이 발생하는 등의 문제가 있었습니다.
* 따라서, 가상 키보드가 올라올 때에만 screen.height기반으로 높이를 새롭게 구해서 form요소들이 찌그러지지않고 렌더링 될 수 있는 Custom hook을 구현하고 form 요소들을 Wrapping하는 요소에 height으로 그 값을 부여함으로써 가상키보드가 올라오는 경우에만 screen.height을 이용하고 이외에는 vh단위를 사용하도록 분기처리했습니다.

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지