### PR TITLE
[로직 강화] Suspense 위치 변경 및 Header 컴포넌트 Router로 이동

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,9 +11,7 @@ const App = () => {
         <RecoilRoot>
             <GlobalStyle />
             <ThemeProvider theme={theme}>
-                <Suspense fallback={<div>Loading...</div>}>
-                    <Router />
-                </Suspense>
+                <Router />
             </ThemeProvider>
         </RecoilRoot>
     );

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Main from './pages/Main';
@@ -19,15 +19,17 @@ const Router = () => {
                 <Route
                     path="/"
                     element={
-                        <AuthRoute>
-                            <Main />
+                        <AuthRoute current={'main'}>
+                            <Suspense fallback={<div>Loading...</div>}>
+                                <Main />
+                            </Suspense>
                         </AuthRoute>
                     }
                 />
                 <Route
                     path="/calendar"
                     element={
-                        <AuthRoute>
+                        <AuthRoute current={'calendar'}>
                             <Calendar />
                         </AuthRoute>
                     }
@@ -35,8 +37,10 @@ const Router = () => {
                 <Route
                     path="/statistics"
                     element={
-                        <AuthRoute>
-                            <Statistics />
+                        <AuthRoute current={'statistics'}>
+                            <Suspense fallback={<div>Loading...</div>}>
+                                <Statistics />
+                            </Suspense>
                         </AuthRoute>
                     }
                 />

--- a/frontend/src/components/AuthRoute/index.jsx
+++ b/frontend/src/components/AuthRoute/index.jsx
@@ -2,9 +2,18 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-const AuthRoute = ({ children }) => {
+import Header from '../../components/Header';
+
+const AuthRoute = ({ children, ...rest }) => {
     const userJwt = sessionStorage.getItem('userJwt');
-    return userJwt ? children : <Navigate replace to="/login" />;
+    return userJwt ? (
+        <>
+            <Header {...rest} />
+            {children}
+        </>
+    ) : (
+        <Navigate replace to="/login" />
+    );
 };
 
 AuthRoute.propTypes = {

--- a/frontend/src/pages/Calendar/index.jsx
+++ b/frontend/src/pages/Calendar/index.jsx
@@ -6,12 +6,14 @@ import { MainWrapper } from './style';
 
 const Calendar = () => {
     return (
-        <Suspense fallback={<div>Loading...</div>}>
+        <>
             <Header current={'calendar'} />
             <MainWrapper>
-                <CalendarTable />
+                <Suspense fallback={<div>Loading...</div>}>
+                    <CalendarTable />
+                </Suspense>
             </MainWrapper>
-        </Suspense>
+        </>
     );
 };
 

--- a/frontend/src/pages/Calendar/index.jsx
+++ b/frontend/src/pages/Calendar/index.jsx
@@ -6,14 +6,11 @@ import { MainWrapper } from './style';
 
 const Calendar = () => {
     return (
-        <>
-            <Header current={'calendar'} />
-            <MainWrapper>
-                <Suspense fallback={<div>Loading...</div>}>
-                    <CalendarTable />
-                </Suspense>
-            </MainWrapper>
-        </>
+        <MainWrapper>
+            <Suspense fallback={<div>Loading...</div>}>
+                <CalendarTable />
+            </Suspense>
+        </MainWrapper>
     );
 };
 

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -20,16 +20,15 @@ const Main = () => {
     }, []);
 
     return (
-        <Suspense fallback={<div>Loading...</div>}>
-            <Header current={'main'} />
-            <MainWrapper>
+        <MainWrapper>
+            <Suspense fallback={<div>Loading...</div>}>
                 <Summary />
                 <TransactionBox>
                     <TransactionCreator />
                     <Transactions transactions={filterdTransactions} />
                 </TransactionBox>
-            </MainWrapper>
-        </Suspense>
+            </Suspense>
+        </MainWrapper>
     );
 };
 

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -16,9 +16,8 @@ const Statistics = () => {
     const categoryTransaction = getOpenModalByName('categoryTransaction');
 
     return (
-        <Suspense fallback={<div>Loading...</div>}>
-            <Header current={'statistics'} />
-            <MainWrapper>
+        <MainWrapper>
+            <Suspense fallback={<div>Loading...</div>}>
                 {expenditures !== 0 ? (
                     <DonutBox data-testid="donut">
                         <Donut transactionsByCategory={transactionsByCategory} />
@@ -27,11 +26,12 @@ const Statistics = () => {
                 ) : (
                     <EmptyBox />
                 )}
-                {categoryTransaction ? (
-                    <Transactions transactions={categoryTransaction.props} width={75} />
-                ) : null}
-            </MainWrapper>
-        </Suspense>
+            </Suspense>
+
+            {categoryTransaction ? (
+                <Transactions transactions={categoryTransaction.props} width={75} />
+            ) : null}
+        </MainWrapper>
     );
 };
 


### PR DESCRIPTION
### 기존의 Header가  Suspense fallback 로딩컴포넌트로 감싸진 경우(좌), 개선된 경우(우)
![image](https://user-images.githubusercontent.com/67899069/154910741-74338ab8-1a68-4dbf-abae-661e5cb5bddb.png)![image](https://user-images.githubusercontent.com/67899069/154910756-3ffaeace-7931-46a2-9cd2-626b839b7e0a.png)

## 구현한 내용
* Selector 비동기 로직 처리 시 로딩컴포넌트로 감싸지는 Suspense를 Header가 영향받지 않도록 수정했습니다.
    * 기존의 코드는 Header 또한 상위 Router에 감싸진 Suspense에 의해 함께 로딩 컴포넌트로 대체되는 부분이 있었습니다.
    * 로딩이 필요한 컴포넌트가 아닌 부분 모두 로딩 컴포넌트로 대체되는 경우 UX관점에서 좋지 않다고 판단해서 Header 컴포넌트를 상위로 끌어올렸습니다. 

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지