### PR TITLE
[로직 강화] Donut 컴포넌트 React.memo 적용

### DIFF
--- a/frontend/src/components/Donut/index.jsx
+++ b/frontend/src/components/Donut/index.jsx
@@ -47,4 +47,17 @@ const Donut = ({ transactionsByCategory }) => {
     );
 };
 
-export default Donut;
+const isTransactionsEqual = (prevTransactions, nextTransactions) => {
+    const prev = prevTransactions.transactionsByCategory;
+    const next = nextTransactions.transactionsByCategory;
+
+    if (Object.is(prev, next)) return true;
+    if (prev.size !== next.size) return false;
+
+    const prevEntryArray = Array.from(prev.entries());
+    const nextEntryArray = Array.from(next.entries());
+
+    return JSON.stringify(prevEntryArray) === JSON.stringify(nextEntryArray);
+};
+
+export default React.memo(Donut, isTransactionsEqual);

--- a/frontend/src/pages/Calendar/index.jsx
+++ b/frontend/src/pages/Calendar/index.jsx
@@ -1,6 +1,5 @@
 import React, { Suspense } from 'react';
 
-import Header from '../../components/Header';
 import CalendarTable from '../../components/CalendarTable';
 import { MainWrapper } from './style';
 

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -1,7 +1,6 @@
 import React, { Suspense, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
-import Header from '../../components/Header';
 import Summary from '../../components/Summary';
 import TransactionCreator from '../../components/TransactionCreator';
 import Transactions from '../../components/Transactions';

--- a/frontend/src/pages/Statistics/index.jsx
+++ b/frontend/src/pages/Statistics/index.jsx
@@ -1,6 +1,5 @@
 import React, { Suspense } from 'react';
 
-import Header from '../../components/Header';
 import Donut from '../../components/Donut';
 import StatisticsContent from '../../components/StatisticsContent';
 import Transactions from '../../components/Transactions';
@@ -27,7 +26,6 @@ const Statistics = () => {
                     <EmptyBox />
                 )}
             </Suspense>
-
             {categoryTransaction ? (
                 <Transactions transactions={categoryTransaction.props} width={75} />
             ) : null}


### PR DESCRIPTION
### 기존의 Donut, 카테고리 별 통계 영역 컴포넌트 렌더링 상황(상 - Donut, 하 - 카테고리 별 통계 영역)
![image](https://user-images.githubusercontent.com/67899069/154991434-9e0461f5-971c-4e93-abc1-6e6eb4322142.png)
![image](https://user-images.githubusercontent.com/67899069/154991491-88b27245-e26b-4ef2-b765-5fff53de75ae.png)

### 각각의 컴포넌트에 React.memo를 적용한 경우(상 - Donut, 하 - 카테고리 별 통계 영역)
![image](https://user-images.githubusercontent.com/67899069/154991978-0ba589f0-bafb-40cf-a16a-bb1dbeae26b1.png)
![image](https://user-images.githubusercontent.com/67899069/154991987-518cd914-54fc-4e20-9947-65aee25c5d92.png)

## 구현한 내용
* 같은 props(해당하는 달의 카테고리 별 거래내역)에 대해서 반복적으로 불필요하게 리렌더링이 발생하는 상황이 있어서 React.memo를 적용했습니다.
* Donut, 카테고리 별 통계 영역(staticsContent) 컴포넌트 모두 같은 위치에 위치하고, 같은 props를 내려받습니다.
* 하지만 React.memo는 props에 대해서만 제어를 할 뿐 해당 컴포넌트에 useState와 같은 별도의 상태관리 로직이 존재하는 경우 props가 같더라도 리렌더링이 일어나는 것을 막을 수 없습니다.
* 따라서 위에서 비교한 수치를 보면 알 수 있듯이 컴포넌트 내에서 별도의 상태를 관리하지 않는 Donut 컴포넌트의 경우 초기 한 번 이외에 추가적인 리렌더링이 발생하지 않고, 카테고리 별 통계 영역(staticsContent)은 컴포넌트 내에서 별도의 상태를 관리하기 때문에 추가적인 리렌더링이 계속 발생했음을 확인 할 수 있습니다.
* 따라서, 최종적으로는 Donut 컴포넌트에만 React.memo를 적용했습니다.

## 어려웠던 점 및 해결한 방향
* 해당 컴포넌트가 내려받은 props는 Map 자료구조 기반의 데이터였습니다.
* 단순히 얕은 비교만 하게 되면 같은 데이터가 있더라도, false가 반복되어 React.memo가 적용되지 않았습니다.
* 이를 통해 React.memo에 두 번째 인자로 내부의 값을 비교하는 로직을 추가함으로써 해결할 수 있었습니다.
```
const Donut = ({ transactionsByCategory }) => {
    ...
    return (
        <Wrapper>
            <svg viewBox="0 0 100 100">{circles}</svg>
        </Wrapper>
    );
};

const isTransactionsEqual = (prevTransactions, nextTransactions) => {
    const prev = prevTransactions.transactionsByCategory;
    const next = nextTransactions.transactionsByCategory;

    if (Object.is(prev, next)) return true;
    if (prev.size !== next.size) return false;

    const prevEntryArray = Array.from(prev.entries());
    const nextEntryArray = Array.from(next.entries());

    return JSON.stringify(prevEntryArray) === JSON.stringify(nextEntryArray);
};

export default React.memo(Donut, isTransactionsEqual);
```
* 객체는 JSON.stringify를 통해서 내부의 값을 손쉽게 비교할 수 있습니다.
* 주의해야 할 점은 내부에 있는 데이터가 같더라도 key: value의 순서가 다른 경우 다른 값으로 인식하기 때문에, 넣은 원소의 순서를 보장하는 Map과 달리 항상 일정한 순서를 보장하지 않는 Object의 경우에는 직접 순회하면서 내부의 값을 비교하는 로직을 적용해야 합니다.

## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지