### PR TITLE
[번들링 최적화] Tree Shaking, Code Spliting, Vendor 파일 분리

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,11 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>JH Account Book</title>
-  </head>
-  <body>
-    <div id="root"></div>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>JH Account Book</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+        <script
+            crossorigin
+            src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"
+        ></script>
+    </body>
 </html>

--- a/frontend/src/Router.jsx
+++ b/frontend/src/Router.jsx
@@ -1,50 +1,52 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, lazy } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import Main from './pages/Main';
-import Login from './pages/Login';
-import Calendar from './pages/Calendar';
-import Statistics from './pages/Statistics';
-import GithubOauth from './pages/GithubOauth';
+const Main = lazy(() => import('./pages/Main'));
+const Login = lazy(() => import('./pages/Login'));
+const Calendar = lazy(() => import('./pages/Calendar'));
+const Statistics = lazy(() => import('./pages/Statistics'));
+const GithubOauth = lazy(() => import('./pages/GithubOauth'));
 
-import AuthRoute from './components/AuthRoute';
+const AuthRoute = lazy(() => import('./components/AuthRoute'));
 
 const Router = () => {
     return (
         <BrowserRouter>
-            {/* TODO 설정된 경로 이외의 경로에 대한 Not Found 페이지 렌더링 */}
-            <Routes>
-                <Route path="/login" element={<Login />} />
-                <Route path="/auth" element={<GithubOauth />} />
-                <Route
-                    path="/"
-                    element={
-                        <AuthRoute current={'main'}>
-                            <Suspense fallback={<div>Loading...</div>}>
-                                <Main />
-                            </Suspense>
-                        </AuthRoute>
-                    }
-                />
-                <Route
-                    path="/calendar"
-                    element={
-                        <AuthRoute current={'calendar'}>
-                            <Calendar />
-                        </AuthRoute>
-                    }
-                />
-                <Route
-                    path="/statistics"
-                    element={
-                        <AuthRoute current={'statistics'}>
-                            <Suspense fallback={<div>Loading...</div>}>
-                                <Statistics />
-                            </Suspense>
-                        </AuthRoute>
-                    }
-                />
-            </Routes>
+            <Suspense fallback={<div>Loading...</div>}>
+                {/* TODO 설정된 경로 이외의 경로에 대한 Not Found 페이지 렌더링 */}
+                <Routes>
+                    <Route path="/login" element={<Login />} />
+                    <Route path="/auth" element={<GithubOauth />} />
+                    <Route
+                        path="/"
+                        element={
+                            <AuthRoute current={'main'}>
+                                <Suspense fallback={<div>Loading...</div>}>
+                                    <Main />
+                                </Suspense>
+                            </AuthRoute>
+                        }
+                    />
+                    <Route
+                        path="/calendar"
+                        element={
+                            <AuthRoute current={'calendar'}>
+                                <Calendar />
+                            </AuthRoute>
+                        }
+                    />
+                    <Route
+                        path="/statistics"
+                        element={
+                            <AuthRoute current={'statistics'}>
+                                <Suspense fallback={<div>Loading...</div>}>
+                                    <Statistics />
+                                </Suspense>
+                            </AuthRoute>
+                        }
+                    />
+                </Routes>
+            </Suspense>
         </BrowserRouter>
     );
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
@@ -39,6 +40,10 @@ module.exports = {
         }),
         new Dotenv({ path: './.env' }),
         new BundleAnalyzerPlugin(),
+        new webpack.IgnorePlugin({
+            resourceRegExp: /^\.\/locale$/,
+            contextRegExp: /moment$/,
+        }),
     ],
     optimization: {
         minimize: true,

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -68,6 +68,10 @@ module.exports = {
             },
         },
     },
+    externals: {
+        react: 'React',
+        'react-dom': 'ReactDOM',
+    },
     devServer: {
         port: 9000,
         historyApiFallback: true,

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -57,6 +57,16 @@ module.exports = {
                 },
             }),
         ],
+        splitChunks: {
+            cacheGroups: {
+                vendor: {
+                    test: /[\\/]node_modules[\\/](react|react-dom|recoil)[\\/]/,
+                    name: 'vendor',
+                    chunks: 'all',
+                    filename: `[name].[chunkhash].js`,
+                },
+            },
+        },
     },
     devServer: {
         port: 9000,


### PR DESCRIPTION
## 구현한 내용
1. Tree Shaking
* 사용하는 써드파티 라이브러리 중 moment가 차지하는 크기가 매우크다는 사실을 알게되었습니다.
* 가장 주된 원인은 사용하지 않는 locale이였기 때문에 해당 속성을 사용하지 않도록 함으로써 200KB의 용량을 감소시킬 수 있었습니다.
2. Code Spliting
* SPA 특성 상 모든 자료들을 한 번에 요청해서 번들링 파일이 비대해지는 문제가 있었습니다.
* 따라서, 페이지 별로 필요한 컴포넌트를 동적으로 렌더링하도록 Code Spliting을 적용했습니다.
* 이 과정을 통해 전체 번들링 크기는 비슷하지만 각 번들링 파일의 크기는 크게 감소시킬 수 있었습니다.
3. Vendor 파일 분리
* node_modules의 경우에도 한 파일에 용량을 크게 잡아먹는 문제가 있었기 때문에 chunk 파일로 나눔으로써 번들링 된 파일들 중 가장 큰 파일이 189.44KB가 되도록 개선할 수 있었습니다.
4. 추가적으로 번들라이저를 통해서 entry 번들링 파일에 용량을 크게 차지하는 요소를 분석한 결과 React-dom이 큰 부분을 차지했기 때문에 해당 부분을 external 처리함으로써, entry 파일에 필요한 번들링 파일을 최종적으로 154KB까지 개선했습니다.
  
## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지