### PR TITLE
[Issue Fix] 모바일 버전에서 가상 키보드가 내려오면 box 높이를 재정의 하는 로직 수정

### DIFF
--- a/frontend/src/components/CategoryCreateForm/index.jsx
+++ b/frontend/src/components/CategoryCreateForm/index.jsx
@@ -28,7 +28,7 @@ const CategoryForm = ({ active, category, onCreate, onCancle }) => {
             aria-label="categoryCreate"
             active={active}
             onSubmit={(e) => handleUpdateSubmit(sign, e)}
-            mobileHeight={resizeHeight}
+            heightOnKeyboard={resizeHeight === window.innerHeight ? null : resizeHeight}
         >
             <CostType>
                 <TypeButton

--- a/frontend/src/components/CategoryCreateForm/style.js
+++ b/frontend/src/components/CategoryCreateForm/style.js
@@ -25,7 +25,7 @@ export const Wrapper = styled.form`
         position: absolute;
 
         width: 100vw;
-        height: ${(props) => (props.mobileHeight ? props.mobileHeight + 'px' : '100vh')};
+        height: ${(props) => (props.heightOnKeyboard ? props.heightOnKeyboard + 'px' : '100vh')};
         top: 0;
         left: 0;
         transform: none;

--- a/frontend/src/components/Transaction/style.js
+++ b/frontend/src/components/Transaction/style.js
@@ -40,7 +40,9 @@ export const Category = styled.span`
     box-sizing: border-box;
 
     color: ${({ theme }) => theme.color.white};
-    background-color: ${(props) => props.color};
+    background-color: ${({ theme }) =>
+        (props) =>
+            props.color || theme.color.black};
 
     overflow: hidden;
     text-overflow: ellipsis;

--- a/frontend/src/components/TransactionCreateForm/index.jsx
+++ b/frontend/src/components/TransactionCreateForm/index.jsx
@@ -41,7 +41,7 @@ const TransactionCreateForm = ({ transaction, onCreate, onCancle }) => {
         <Wrapper
             aria-label="transactionCreate"
             onSubmit={handleCreateSubmit}
-            mobileHeight={resizeHeight}
+            heightOnKeyboard={resizeHeight === window.innerHeight ? null : resizeHeight}
         >
             <Element>
                 <button type="button" aria-label="back" onClick={onCancle}>

--- a/frontend/src/components/TransactionCreateForm/style.js
+++ b/frontend/src/components/TransactionCreateForm/style.js
@@ -25,7 +25,7 @@ export const Wrapper = styled.form`
         position: absolute;
 
         width: 100vw;
-        height: ${(props) => (props.mobileHeight ? props.mobileHeight + 'px' : '100vh')};
+        height: ${(props) => (props.heightOnKeyboard ? props.heightOnKeyboard + 'px' : '100vh')};
         top: 0;
         left: 0;
         transform: none;

--- a/frontend/src/components/TransactionUpdateForm/index.jsx
+++ b/frontend/src/components/TransactionUpdateForm/index.jsx
@@ -41,7 +41,7 @@ const TransactionUpdateForm = ({ transaction, onUpdate, onDelete, onCancle }) =>
         <Wrapper
             aria-label="transactionUpdate"
             onSubmit={handleUpdateSubmit}
-            mobileHeight={resizeHeight}
+            heightOnKeyboard={resizeHeight === window.innerHeight ? null : resizeHeight}
         >
             <Element>
                 <button type="button" aria-label="back" onClick={onCancle}>

--- a/frontend/src/components/TransactionUpdateForm/style.js
+++ b/frontend/src/components/TransactionUpdateForm/style.js
@@ -25,7 +25,7 @@ export const Wrapper = styled.form`
         position: absolute;
 
         width: 100vw;
-        height: ${(props) => (props.mobileHeight ? props.mobileHeight + 'px' : '100vh')};
+        height: ${(props) => (props.heightOnKeyboard ? props.heightOnKeyboard + 'px' : '100vh')};
         top: 0;
         left: 0;
         transform: none;

--- a/frontend/src/hooks/useResizeHeight.js
+++ b/frontend/src/hooks/useResizeHeight.js
@@ -1,14 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 export const useResizeHeight = () => {
-    const [resizeHeight, setResizeHeight] = useState(null);
+    const normalHeight = useRef(window.innerHeight);
+    const [resizeHeight, setResizeHeight] = useState(window.innerHeight);
 
     const updateHieght = () => {
-        if (resizeHeight == null) {
-            setResizeHeight(window.screen.availHeight);
+        if (normalHeight.current !== window.innerHeight) {
+            setResizeHeight(window.screen.height);
             return;
         }
-        setResizeHeight(null);
+        setResizeHeight(normalHeight.current);
     };
 
     useEffect(() => {
@@ -16,7 +17,7 @@ export const useResizeHeight = () => {
         return () => {
             window.removeEventListener('resize', updateHieght);
         };
-    });
+    }, []);
 
     return { resizeHeight };
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
             template: './public/index.html',
         }),
         new Dotenv({ path: './.env' }),
-        new BundleAnalyzerPlugin(),
+        new BundleAnalyzerPlugin({ analyzerMode: 'static' }),
         new webpack.IgnorePlugin({
             resourceRegExp: /^\.\/locale$/,
             contextRegExp: /moment$/,


### PR DESCRIPTION
## 구현한 내용
1. 카테고리 항목이 미분류인 경우에 대한 분기로직을 추가했습니다.
2. 모바일버전에서 가상키보드가 올라오는 경우 box의 높이를 재정의 하는 로직을 수정했습니다.
* 가상키보드가 올라오지 않은 초기의 디바이스 내부의 높이를 useRef의 값으로 초기화합니다.
* 이후 window에 resize이벤트를 달아서 디바이스 내부의 높이가 변경된 경우(여기서는 가상키보드만을 고려했습니다.) 기존의 초기 높이값과 비교해서 만약 다른경우 모바일 자체의 해상도를 높이로 box 크기를 변경해서 입력 form이 찌그러지는 것을 방지하도록 했습니다.
  
## 체크리스트
- [x]  `console.log` 지우고 올리기(TODO 익스텐션 제외)
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 금지